### PR TITLE
Language injection

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@ platformVersion = 2020.3.2
 #platformVersion = 211.6432.7-EAP-SNAPSHOT
 platformDownloadSources = true
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
-platformPlugins =
+platformPlugins = org.intellij.intelliLang

--- a/src/grammar/cue.bnf
+++ b/src/grammar/cue.bnf
@@ -102,22 +102,30 @@ ImportPath       ::= "\"" ImportLocation [ ":" identifier ] "\""
 simple_string_lit ::= DOUBLE_QUOTE { unicode_value | interpolation }* DOUBLE_QUOTE_END {
    pin=1
    extends=Literal
+   implements=["dev.monogon.cue.lang.psi.CueStringLiteral" "com.intellij.psi.PsiLanguageInjectionHost"]
+   mixin="dev.monogon.cue.lang.psi.impl.CueSimpleStringLiteralMixin"
+   methods=[openingQuote="DOUBLE_QUOTE" closingQuote="DOUBLE_QUOTE_END"]
 }
-simple_bytes_lit ::=  SINGLE_QUOTE { unicode_value | interpolation | BYTE_VALUE }* SINGLE_QUOTE_END {
+simple_bytes_lit ::= SINGLE_QUOTE { unicode_value | interpolation | BYTE_VALUE }* SINGLE_QUOTE_END {
     pin=1
     extends=Literal
+    implements=["dev.monogon.cue.lang.psi.CueStringLiteral" "com.intellij.psi.PsiLanguageInjectionHost"]
+    mixin="dev.monogon.cue.lang.psi.impl.CueSimpleByteLiteralMixin"
+    methods=[openingQuote="SINGLE_QUOTE" closingQuote="SINGLE_QUOTE_END"]
 }
 multiline_string_lit ::= MULTILINE_STRING_START NEWLINE { unicode_value | interpolation | NEWLINE }* NEWLINE* MULTILINE_STRING_END {
     pin=1
     extends=Literal
-    implements=["dev.monogon.cue.lang.psi.CueMultilineLiteral"]
-    methods=[literalStartElement="MULTILINE_STRING_START" literalEndElement="MULTILINE_STRING_END"]
+    implements=["dev.monogon.cue.lang.psi.CueMultilineLiteral" "com.intellij.psi.PsiLanguageInjectionHost"]
+    mixin="dev.monogon.cue.lang.psi.impl.CueMultilineStringLiteralMixin"
+    methods=[openingQuote="MULTILINE_STRING_START" closingQuote="MULTILINE_STRING_END"]
 }
 multiline_bytes_lit ::= MULTILINE_BYTES_START NEWLINE { unicode_value | interpolation | BYTE_VALUE | NEWLINE }* NEWLINE* MULTILINE_BYTES_END {
     pin=1
     extends=Literal
-    implements=["dev.monogon.cue.lang.psi.CueMultilineLiteral"]
-    methods=[literalStartElement="MULTILINE_BYTES_START" literalEndElement="MULTILINE_BYTES_END"]
+    implements=["dev.monogon.cue.lang.psi.CueMultilineLiteral" "com.intellij.psi.PsiLanguageInjectionHost"]
+    mixin="dev.monogon.cue.lang.psi.impl.CueMultilineBytesLiteralMixin"
+    methods=[openingQuote="MULTILINE_BYTES_START" closingQuote="MULTILINE_BYTES_END"]
 }
 
 interpolation ::= INTERPOLATION_START Expression INTERPOLATION_END { pin=1 }
@@ -127,7 +135,7 @@ private string_lit ::= simple_string_lit
                    | simple_bytes_lit
                    | multiline_bytes_lit
                    | "#" string_lit "#"
-private string_lit_recover ::= !(DOUBLE_QUOTE | DOUBLE_QUOTE_END | SINGLE_QUOTE | SINGLE_QUOTE_END | MULTILINE_STRING_START | MULTILINE_STRING_END | MULTILINE_BYTES_START | MULTILINE_BYTES_END)
+//private string_lit_recover ::= !(DOUBLE_QUOTE | DOUBLE_QUOTE_END | SINGLE_QUOTE | SINGLE_QUOTE_END | MULTILINE_STRING_START | MULTILINE_STRING_END | MULTILINE_BYTES_START | MULTILINE_BYTES_END)
 
 // IntelliJ: extension to handle our known identifier tokens, identifier_PREDECLARED is mostly for highlighting 
 private identifier ::= IDENTIFIER | IDENTIFIER_PREDECLARED
@@ -178,7 +186,7 @@ ElementList   ::= Embedding { comma Embedding }*
 // https://cuelang.org/docs/references/spec/#expressions
 Operand     ::= Literal | OperandName | "(" Expression ")" {extends=PrimaryExpr}
 Literal     ::= BasicLit | ListLit | StructLit {extends=Operand}
-BasicLit    ::= INT_LIT | FLOAT_LIT | string_lit | NULL_LIT | BOOL_LIT | BOTTOM_LIT {extends=Literal}
+BasicLit    ::= INT_LIT | FLOAT_LIT | string_lit | NULL_LIT | BOOL_LIT | BOTTOM_LIT {extends=Literal methods=[Literal=""]}
 OperandName ::= <<identifier_ref>> | QualifiedIdent {extends=Operand}
 
 QualifiedIdent ::= PackageName "." <<identifier_ref>> {extends=Operand}

--- a/src/main/java-gen/dev/monogon/cue/lang/parser/CueParser.java
+++ b/src/main/java-gen/dev/monogon/cue/lang/parser/CueParser.java
@@ -1417,32 +1417,6 @@ public class CueParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // !(DOUBLE_QUOTE | DOUBLE_QUOTE_END | SINGLE_QUOTE | SINGLE_QUOTE_END | MULTILINE_STRING_START | MULTILINE_STRING_END | MULTILINE_BYTES_START | MULTILINE_BYTES_END)
-  static boolean string_lit_recover(PsiBuilder b, int l) {
-    if (!recursion_guard_(b, l, "string_lit_recover")) return false;
-    boolean r;
-    Marker m = enter_section_(b, l, _NOT_);
-    r = !string_lit_recover_0(b, l + 1);
-    exit_section_(b, l, m, r, false, null);
-    return r;
-  }
-
-  // DOUBLE_QUOTE | DOUBLE_QUOTE_END | SINGLE_QUOTE | SINGLE_QUOTE_END | MULTILINE_STRING_START | MULTILINE_STRING_END | MULTILINE_BYTES_START | MULTILINE_BYTES_END
-  private static boolean string_lit_recover_0(PsiBuilder b, int l) {
-    if (!recursion_guard_(b, l, "string_lit_recover_0")) return false;
-    boolean r;
-    r = consumeTokenFast(b, DOUBLE_QUOTE);
-    if (!r) r = consumeTokenFast(b, DOUBLE_QUOTE_END);
-    if (!r) r = consumeTokenFast(b, SINGLE_QUOTE);
-    if (!r) r = consumeTokenFast(b, SINGLE_QUOTE_END);
-    if (!r) r = consumeTokenFast(b, MULTILINE_STRING_START);
-    if (!r) r = consumeTokenFast(b, MULTILINE_STRING_END);
-    if (!r) r = consumeTokenFast(b, MULTILINE_BYTES_START);
-    if (!r) r = consumeTokenFast(b, MULTILINE_BYTES_END);
-    return r;
-  }
-
-  /* ********************************************************** */
   // ADD_OP | EXCL | "*" | rel_op
   static boolean unary_op(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "unary_op")) return false;

--- a/src/main/java-gen/dev/monogon/cue/lang/psi/CueBasicLit.java
+++ b/src/main/java-gen/dev/monogon/cue/lang/psi/CueBasicLit.java
@@ -7,7 +7,4 @@ import com.intellij.psi.PsiElement;
 
 public interface CueBasicLit extends CueLiteral {
 
-  @Nullable
-  CueLiteral getLiteral();
-
 }

--- a/src/main/java-gen/dev/monogon/cue/lang/psi/CueMultilineBytesLit.java
+++ b/src/main/java-gen/dev/monogon/cue/lang/psi/CueMultilineBytesLit.java
@@ -4,16 +4,17 @@ package dev.monogon.cue.lang.psi;
 import java.util.List;
 import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiLanguageInjectionHost;
 
-public interface CueMultilineBytesLit extends CueLiteral, CueMultilineLiteral {
+public interface CueMultilineBytesLit extends CueLiteral, CueMultilineLiteral, PsiLanguageInjectionHost {
 
   @NotNull
   List<CueInterpolation> getInterpolationList();
 
   @NotNull
-  PsiElement getLiteralStartElement();
+  PsiElement getOpeningQuote();
 
   @Nullable
-  PsiElement getLiteralEndElement();
+  PsiElement getClosingQuote();
 
 }

--- a/src/main/java-gen/dev/monogon/cue/lang/psi/CueMultilineStringLit.java
+++ b/src/main/java-gen/dev/monogon/cue/lang/psi/CueMultilineStringLit.java
@@ -4,16 +4,17 @@ package dev.monogon.cue.lang.psi;
 import java.util.List;
 import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiLanguageInjectionHost;
 
-public interface CueMultilineStringLit extends CueLiteral, CueMultilineLiteral {
+public interface CueMultilineStringLit extends CueLiteral, CueMultilineLiteral, PsiLanguageInjectionHost {
 
   @NotNull
   List<CueInterpolation> getInterpolationList();
 
   @NotNull
-  PsiElement getLiteralStartElement();
+  PsiElement getOpeningQuote();
 
   @Nullable
-  PsiElement getLiteralEndElement();
+  PsiElement getClosingQuote();
 
 }

--- a/src/main/java-gen/dev/monogon/cue/lang/psi/CueSimpleBytesLit.java
+++ b/src/main/java-gen/dev/monogon/cue/lang/psi/CueSimpleBytesLit.java
@@ -4,10 +4,17 @@ package dev.monogon.cue.lang.psi;
 import java.util.List;
 import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiLanguageInjectionHost;
 
-public interface CueSimpleBytesLit extends CueLiteral {
+public interface CueSimpleBytesLit extends CueLiteral, CueStringLiteral, PsiLanguageInjectionHost {
 
   @NotNull
   List<CueInterpolation> getInterpolationList();
+
+  @NotNull
+  PsiElement getOpeningQuote();
+
+  @Nullable
+  PsiElement getClosingQuote();
 
 }

--- a/src/main/java-gen/dev/monogon/cue/lang/psi/CueSimpleStringLit.java
+++ b/src/main/java-gen/dev/monogon/cue/lang/psi/CueSimpleStringLit.java
@@ -4,10 +4,17 @@ package dev.monogon.cue.lang.psi;
 import java.util.List;
 import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiLanguageInjectionHost;
 
-public interface CueSimpleStringLit extends CueLiteral {
+public interface CueSimpleStringLit extends CueLiteral, CueStringLiteral, PsiLanguageInjectionHost {
 
   @NotNull
   List<CueInterpolation> getInterpolationList();
+
+  @NotNull
+  PsiElement getOpeningQuote();
+
+  @Nullable
+  PsiElement getClosingQuote();
 
 }

--- a/src/main/java-gen/dev/monogon/cue/lang/psi/CueVisitor.java
+++ b/src/main/java-gen/dev/monogon/cue/lang/psi/CueVisitor.java
@@ -3,6 +3,7 @@ package dev.monogon.cue.lang.psi;
 
 import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.PsiLanguageInjectionHost;
 
 public class CueVisitor extends PsiElementVisitor {
 
@@ -166,19 +167,25 @@ public class CueVisitor extends PsiElementVisitor {
   public void visitMultilineBytesLit(@NotNull CueMultilineBytesLit o) {
     visitLiteral(o);
     // visitMultilineLiteral(o);
+    // visitPsiLanguageInjectionHost(o);
   }
 
   public void visitMultilineStringLit(@NotNull CueMultilineStringLit o) {
     visitLiteral(o);
     // visitMultilineLiteral(o);
+    // visitPsiLanguageInjectionHost(o);
   }
 
   public void visitSimpleBytesLit(@NotNull CueSimpleBytesLit o) {
     visitLiteral(o);
+    // visitStringLiteral(o);
+    // visitPsiLanguageInjectionHost(o);
   }
 
   public void visitSimpleStringLit(@NotNull CueSimpleStringLit o) {
     visitLiteral(o);
+    // visitStringLiteral(o);
+    // visitPsiLanguageInjectionHost(o);
   }
 
   public void visitBlock(@NotNull CueBlock o) {

--- a/src/main/java-gen/dev/monogon/cue/lang/psi/impl/CueBasicLitImpl.java
+++ b/src/main/java-gen/dev/monogon/cue/lang/psi/impl/CueBasicLitImpl.java
@@ -27,10 +27,4 @@ public class CueBasicLitImpl extends CueLiteralImpl implements CueBasicLit {
     else super.accept(visitor);
   }
 
-  @Override
-  @Nullable
-  public CueLiteral getLiteral() {
-    return findChildByClass(CueLiteral.class);
-  }
-
 }

--- a/src/main/java-gen/dev/monogon/cue/lang/psi/impl/CueMultilineBytesLitImpl.java
+++ b/src/main/java-gen/dev/monogon/cue/lang/psi/impl/CueMultilineBytesLitImpl.java
@@ -10,13 +10,12 @@ import com.intellij.psi.util.PsiTreeUtil;
 import static dev.monogon.cue.lang.CueTypes.*;
 import dev.monogon.cue.lang.psi.*;
 
-public class CueMultilineBytesLitImpl extends CueLiteralImpl implements CueMultilineBytesLit {
+public class CueMultilineBytesLitImpl extends CueMultilineBytesLiteralMixin implements CueMultilineBytesLit {
 
   public CueMultilineBytesLitImpl(@NotNull ASTNode node) {
     super(node);
   }
 
-  @Override
   public void accept(@NotNull CueVisitor visitor) {
     visitor.visitMultilineBytesLit(this);
   }
@@ -35,13 +34,13 @@ public class CueMultilineBytesLitImpl extends CueLiteralImpl implements CueMulti
 
   @Override
   @NotNull
-  public PsiElement getLiteralStartElement() {
+  public PsiElement getOpeningQuote() {
     return findNotNullChildByType(MULTILINE_BYTES_START);
   }
 
   @Override
   @Nullable
-  public PsiElement getLiteralEndElement() {
+  public PsiElement getClosingQuote() {
     return findChildByType(MULTILINE_BYTES_END);
   }
 

--- a/src/main/java-gen/dev/monogon/cue/lang/psi/impl/CueMultilineStringLitImpl.java
+++ b/src/main/java-gen/dev/monogon/cue/lang/psi/impl/CueMultilineStringLitImpl.java
@@ -10,13 +10,12 @@ import com.intellij.psi.util.PsiTreeUtil;
 import static dev.monogon.cue.lang.CueTypes.*;
 import dev.monogon.cue.lang.psi.*;
 
-public class CueMultilineStringLitImpl extends CueLiteralImpl implements CueMultilineStringLit {
+public class CueMultilineStringLitImpl extends CueMultilineStringLiteralMixin implements CueMultilineStringLit {
 
   public CueMultilineStringLitImpl(@NotNull ASTNode node) {
     super(node);
   }
 
-  @Override
   public void accept(@NotNull CueVisitor visitor) {
     visitor.visitMultilineStringLit(this);
   }
@@ -35,13 +34,13 @@ public class CueMultilineStringLitImpl extends CueLiteralImpl implements CueMult
 
   @Override
   @NotNull
-  public PsiElement getLiteralStartElement() {
+  public PsiElement getOpeningQuote() {
     return findNotNullChildByType(MULTILINE_STRING_START);
   }
 
   @Override
   @Nullable
-  public PsiElement getLiteralEndElement() {
+  public PsiElement getClosingQuote() {
     return findChildByType(MULTILINE_STRING_END);
   }
 

--- a/src/main/java-gen/dev/monogon/cue/lang/psi/impl/CueSimpleBytesLitImpl.java
+++ b/src/main/java-gen/dev/monogon/cue/lang/psi/impl/CueSimpleBytesLitImpl.java
@@ -10,13 +10,12 @@ import com.intellij.psi.util.PsiTreeUtil;
 import static dev.monogon.cue.lang.CueTypes.*;
 import dev.monogon.cue.lang.psi.*;
 
-public class CueSimpleBytesLitImpl extends CueLiteralImpl implements CueSimpleBytesLit {
+public class CueSimpleBytesLitImpl extends CueSimpleByteLiteralMixin implements CueSimpleBytesLit {
 
   public CueSimpleBytesLitImpl(@NotNull ASTNode node) {
     super(node);
   }
 
-  @Override
   public void accept(@NotNull CueVisitor visitor) {
     visitor.visitSimpleBytesLit(this);
   }
@@ -31,6 +30,18 @@ public class CueSimpleBytesLitImpl extends CueLiteralImpl implements CueSimpleBy
   @NotNull
   public List<CueInterpolation> getInterpolationList() {
     return PsiTreeUtil.getChildrenOfTypeAsList(this, CueInterpolation.class);
+  }
+
+  @Override
+  @NotNull
+  public PsiElement getOpeningQuote() {
+    return findNotNullChildByType(SINGLE_QUOTE);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getClosingQuote() {
+    return findChildByType(SINGLE_QUOTE_END);
   }
 
 }

--- a/src/main/java-gen/dev/monogon/cue/lang/psi/impl/CueSimpleStringLitImpl.java
+++ b/src/main/java-gen/dev/monogon/cue/lang/psi/impl/CueSimpleStringLitImpl.java
@@ -10,13 +10,12 @@ import com.intellij.psi.util.PsiTreeUtil;
 import static dev.monogon.cue.lang.CueTypes.*;
 import dev.monogon.cue.lang.psi.*;
 
-public class CueSimpleStringLitImpl extends CueLiteralImpl implements CueSimpleStringLit {
+public class CueSimpleStringLitImpl extends CueSimpleStringLiteralMixin implements CueSimpleStringLit {
 
   public CueSimpleStringLitImpl(@NotNull ASTNode node) {
     super(node);
   }
 
-  @Override
   public void accept(@NotNull CueVisitor visitor) {
     visitor.visitSimpleStringLit(this);
   }
@@ -31,6 +30,18 @@ public class CueSimpleStringLitImpl extends CueLiteralImpl implements CueSimpleS
   @NotNull
   public List<CueInterpolation> getInterpolationList() {
     return PsiTreeUtil.getChildrenOfTypeAsList(this, CueInterpolation.class);
+  }
+
+  @Override
+  @NotNull
+  public PsiElement getOpeningQuote() {
+    return findNotNullChildByType(DOUBLE_QUOTE);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getClosingQuote() {
+    return findChildByType(DOUBLE_QUOTE_END);
   }
 
 }

--- a/src/main/java/dev/monogon/cue/lang/editor/folding/CueFoldingBuilder.java
+++ b/src/main/java/dev/monogon/cue/lang/editor/folding/CueFoldingBuilder.java
@@ -67,7 +67,7 @@ public class CueFoldingBuilder extends FoldingBuilderEx implements DumbAware {
     }
 
     private void foldMultilineLiteral(CueMultilineLiteral literal, List<FoldingDescriptor> result) {
-        if (literal.getLiteralStartElement() == null) {
+        if (literal.getOpeningQuote() == null) {
             return;
         }
 

--- a/src/main/java/dev/monogon/cue/lang/editor/formatter/ExternalCueFormatter.java
+++ b/src/main/java/dev/monogon/cue/lang/editor/formatter/ExternalCueFormatter.java
@@ -71,6 +71,10 @@ public class ExternalCueFormatter implements ExternalFormatProcessor {
                 var newContent = CueCommandService.getInstance().format(document.getText(), 5, TimeUnit.SECONDS);
                 if (newContent != null) {
                     app.invokeLater(() -> {
+                        if (!file.isValid()) {
+                            return;
+                        }
+
                         var processor = CommandProcessor.getInstance();
                         processor.runUndoTransparentAction(() -> app.runWriteAction(() -> document.setText(newContent)));
                     });

--- a/src/main/java/dev/monogon/cue/lang/elementManipulator/AbstractStringLiteralElementManipulator.java
+++ b/src/main/java/dev/monogon/cue/lang/elementManipulator/AbstractStringLiteralElementManipulator.java
@@ -4,7 +4,7 @@ import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.ElementManipulator;
 import com.intellij.util.IncorrectOperationException;
 import dev.monogon.cue.lang.psi.*;
-import dev.monogon.cue.lang.util.TextEscaperUtil;
+import dev.monogon.cue.lang.util.CueEscaperUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -33,12 +33,12 @@ abstract class AbstractStringLiteralElementManipulator<T extends CueStringLitera
                                        String newRangeContent) throws IncorrectOperationException {
         var contentRange = getRangeInElement(element);
         var content = contentRange.substring(element.getText());
-        var escapedRangeContent = TextEscaperUtil.escapeCueString(newRangeContent, true, !(element instanceof CueMultilineLiteral),
-                                                                  element instanceof CueSimpleBytesLit,
-                                                                  element instanceof CueSimpleStringLit,
-                                                                  element instanceof CueMultilineBytesLit,
-                                                                  element instanceof CueMultilineStringLit,
-                                                                  element.getEscapePaddingSize());
+        var escapedRangeContent = CueEscaperUtil.escapeCueString(newRangeContent, true, !(element instanceof CueMultilineLiteral), true,
+                                                                 element instanceof CueSimpleBytesLit,
+                                                                 element instanceof CueSimpleStringLit,
+                                                                 element instanceof CueMultilineBytesLit,
+                                                                 element instanceof CueMultilineStringLit,
+                                                                 element.getEscapePaddingSize());
         // it's possible that the current content range is smaller than the passed in range
         // this could happen when an empty multiline string is updated with non-empty content
         var fixedRange = !contentRange.contains(range) ? contentRange.intersection(range) : range;

--- a/src/main/java/dev/monogon/cue/lang/elementManipulator/AbstractStringLiteralElementManipulator.java
+++ b/src/main/java/dev/monogon/cue/lang/elementManipulator/AbstractStringLiteralElementManipulator.java
@@ -1,0 +1,63 @@
+package dev.monogon.cue.lang.elementManipulator;
+
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.ElementManipulator;
+import com.intellij.util.IncorrectOperationException;
+import dev.monogon.cue.lang.psi.*;
+import dev.monogon.cue.lang.util.TextEscaperUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+abstract class AbstractStringLiteralElementManipulator<T extends CueStringLiteral> implements ElementManipulator<T> {
+    /**
+     * Creates a new literal based on the unquoted content.
+     * The caller of this method has to escape the content properly.
+     *
+     * @param element         element to update
+     * @param unquotedContent the new content, without the quotes
+     * @param paddingSize     number of # chars padding the escape prefix, e.g. 2 for \##
+     * @return The new element, if available.
+     */
+    @Nullable
+    protected abstract T createStringLiteral(@NotNull CueStringLiteral element, String unquotedContent, int paddingSize);
+
+    @Override
+    public final @NotNull TextRange getRangeInElement(@NotNull T element) {
+        return element.getLiteralContentRange();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public final T handleContentChange(@NotNull T element,
+                                       @NotNull TextRange range,
+                                       String newRangeContent) throws IncorrectOperationException {
+        var contentRange = getRangeInElement(element);
+        var content = contentRange.substring(element.getText());
+        var escapedRangeContent = TextEscaperUtil.escapeCueString(newRangeContent, true, !(element instanceof CueMultilineLiteral),
+                                                                  element instanceof CueSimpleBytesLit,
+                                                                  element instanceof CueSimpleStringLit,
+                                                                  element instanceof CueMultilineBytesLit,
+                                                                  element instanceof CueMultilineStringLit,
+                                                                  element.getEscapePaddingSize());
+        // it's possible that the current content range is smaller than the passed in range
+        // this could happen when an empty multiline string is updated with non-empty content
+        var fixedRange = !contentRange.contains(range) ? contentRange.intersection(range) : range;
+        var updatedContent = fixedRange.shiftLeft(contentRange.getStartOffset()).replace(content, escapedRangeContent);
+
+        var replacement = createStringLiteral(element, updatedContent, element.getEscapePaddingSize());
+        if (replacement == null) {
+            throw new IncorrectOperationException("unable to create simple string literal for content:" + newRangeContent);
+        }
+
+        var replaced = element.replace(replacement);
+        if (replaced == null) {
+            throw new IncorrectOperationException("unable to replace with new simple string literal for content:" + newRangeContent);
+        }
+        return (T)replaced;
+    }
+
+    @Override
+    public final T handleContentChange(@NotNull T element, String newContent) throws IncorrectOperationException {
+        return handleContentChange(element, getRangeInElement(element), newContent);
+    }
+}

--- a/src/main/java/dev/monogon/cue/lang/elementManipulator/CueMultilineBytesElementManipulator.java
+++ b/src/main/java/dev/monogon/cue/lang/elementManipulator/CueMultilineBytesElementManipulator.java
@@ -1,0 +1,16 @@
+package dev.monogon.cue.lang.elementManipulator;
+
+import dev.monogon.cue.lang.psi.CueMultilineBytesLit;
+import dev.monogon.cue.lang.psi.CuePsiElementFactory;
+import dev.monogon.cue.lang.psi.CueStringLiteral;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class CueMultilineBytesElementManipulator extends AbstractStringLiteralElementManipulator<CueMultilineBytesLit> {
+    @Override
+    protected @Nullable CueMultilineBytesLit createStringLiteral(@NotNull CueStringLiteral element,
+                                                                 String unquotedContent,
+                                                                 int paddingSize) {
+        return CuePsiElementFactory.createMultilineBytesLiteral(element.getProject(), unquotedContent, paddingSize);
+    }
+}

--- a/src/main/java/dev/monogon/cue/lang/elementManipulator/CueMultilineStringElementManipulator.java
+++ b/src/main/java/dev/monogon/cue/lang/elementManipulator/CueMultilineStringElementManipulator.java
@@ -1,0 +1,16 @@
+package dev.monogon.cue.lang.elementManipulator;
+
+import dev.monogon.cue.lang.psi.CueMultilineStringLit;
+import dev.monogon.cue.lang.psi.CuePsiElementFactory;
+import dev.monogon.cue.lang.psi.CueStringLiteral;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class CueMultilineStringElementManipulator extends AbstractStringLiteralElementManipulator<CueMultilineStringLit> {
+    @Override
+    protected @Nullable CueMultilineStringLit createStringLiteral(@NotNull CueStringLiteral element,
+                                                                  String unquotedContent,
+                                                                  int paddingSize) {
+        return CuePsiElementFactory.createMultilineStringLiteral(element.getProject(), unquotedContent, paddingSize);
+    }
+}

--- a/src/main/java/dev/monogon/cue/lang/elementManipulator/CueSimpleBytesElementManipulator.java
+++ b/src/main/java/dev/monogon/cue/lang/elementManipulator/CueSimpleBytesElementManipulator.java
@@ -1,0 +1,14 @@
+package dev.monogon.cue.lang.elementManipulator;
+
+import dev.monogon.cue.lang.psi.CuePsiElementFactory;
+import dev.monogon.cue.lang.psi.CueSimpleBytesLit;
+import dev.monogon.cue.lang.psi.CueStringLiteral;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class CueSimpleBytesElementManipulator extends AbstractStringLiteralElementManipulator<CueSimpleBytesLit> {
+    @Override
+    protected @Nullable CueSimpleBytesLit createStringLiteral(@NotNull CueStringLiteral element, String unquotedContent, int paddingSize) {
+        return CuePsiElementFactory.createSimpleBytesLiteral(element.getProject(), unquotedContent, paddingSize);
+    }
+}

--- a/src/main/java/dev/monogon/cue/lang/elementManipulator/CueSimpleStringElementManipulator.java
+++ b/src/main/java/dev/monogon/cue/lang/elementManipulator/CueSimpleStringElementManipulator.java
@@ -1,0 +1,14 @@
+package dev.monogon.cue.lang.elementManipulator;
+
+import dev.monogon.cue.lang.psi.CuePsiElementFactory;
+import dev.monogon.cue.lang.psi.CueSimpleStringLit;
+import dev.monogon.cue.lang.psi.CueStringLiteral;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class CueSimpleStringElementManipulator extends AbstractStringLiteralElementManipulator<CueSimpleStringLit> {
+    @Override
+    protected @Nullable CueSimpleStringLit createStringLiteral(@NotNull CueStringLiteral element, String unquotedContent, int paddingSize) {
+        return CuePsiElementFactory.createSimpleStringLiteral(element.getProject(), unquotedContent, paddingSize);
+    }
+}

--- a/src/main/java/dev/monogon/cue/lang/injection/CueMultiHostInjector.java
+++ b/src/main/java/dev/monogon/cue/lang/injection/CueMultiHostInjector.java
@@ -1,0 +1,130 @@
+package dev.monogon.cue.lang.injection;
+
+import com.intellij.lang.Language;
+import com.intellij.lang.injection.MultiHostInjector;
+import com.intellij.lang.injection.MultiHostRegistrar;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiLanguageInjectionHost;
+import dev.monogon.cue.lang.psi.CueStringLiteral;
+import org.intellij.plugins.intelliLang.inject.InjectorUtils;
+import org.intellij.plugins.intelliLang.inject.LanguageInjectionSupport;
+import org.intellij.plugins.intelliLang.inject.TemporaryPlacesRegistry;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Injector with knowledge of interpolations in CUE string literals.
+ * Language injection skips the interpolations.
+ * <p>
+ * The default feature to use comments to define language, prefix, and suffix is supported
+ * by leveraging the IntelliLang plugin.
+ */
+public class CueMultiHostInjector implements MultiHostInjector {
+    private static final List<Class<CueStringLiteral>> classes = Collections.singletonList(CueStringLiteral.class);
+
+    @Override
+    public void getLanguagesToInject(@NotNull MultiHostRegistrar registrar, @NotNull PsiElement context) {
+        if (!(context instanceof CueStringLiteral)) {
+            return;
+        }
+
+        var literal = (CueStringLiteral)context;
+        if (!literal.isValidHost()) {
+            return;
+        }
+
+        Optional<LanguageInjectionSupport> injectionSupport = InjectorUtils.getActiveInjectionSupports()
+            .stream()
+            .filter(support -> support.isApplicableTo(literal) && support.useDefaultCommentInjector())
+            .findFirst();
+
+        Language targetLanguage = null;
+        if (injectionSupport.isPresent()) {
+            var injection = injectionSupport.get().findCommentInjection(context, null);
+            if (injection != null) {
+                targetLanguage = injection.getInjectedLanguage();
+            }
+        }
+
+        // our fallbacks: temporary places first
+        if (targetLanguage == null) {
+            var hostFile = context.getContainingFile();
+            var project = hostFile.getProject();
+            var tempInjection = TemporaryPlacesRegistry.getInstance(project).getLanguageFor(literal, hostFile);
+            if (tempInjection != null) {
+                targetLanguage = tempInjection.getLanguage();
+            }
+        }
+
+        // fallback: generic comment implementation
+        if (targetLanguage == null) {
+            var baseInjection = InjectorUtils.findCommentInjection(context, "comment", null);
+            if (baseInjection != null) {
+                targetLanguage = baseInjection.getInjectedLanguage();
+            }
+        }
+
+        // finally, do the injection if a language was found
+        if (targetLanguage != null) {
+            var ranges = findInjectionRanges(literal);
+            if (!ranges.isEmpty()) {
+                registrar.startInjecting(targetLanguage);
+                var last = ranges.size() - 1;
+                for (int i = 0; i <= last; i++) {
+                    var range = ranges.get(i);
+                    registrar.addPlace(range.prefix, range.suffix, (PsiLanguageInjectionHost)context, range.range);
+                }
+                registrar.doneInjecting();
+            }
+        }
+    }
+
+    @Override
+    public @NotNull List<? extends Class<? extends PsiElement>> elementsToInjectIn() {
+        return classes;
+    }
+
+    static List<InjectionData> findInjectionRanges(CueStringLiteral context) {
+        var totalRange = context.getLiteralContentRange();
+        var interpolations = context.getInterpolationList()
+            .stream()
+            .map(PsiElement::getTextRangeInParent)
+            .sorted(Comparator.comparingInt(TextRange::getStartOffset))
+            .collect(Collectors.toList());
+
+        if (interpolations.isEmpty()) {
+            return Collections.singletonList(new InjectionData(totalRange, null, null));
+        }
+
+        var hostText = context.getText();
+        var result = new LinkedList<InjectionData>();
+        var lastStart = totalRange.getStartOffset();
+        var lastEnd = totalRange.getStartOffset();
+        for (TextRange range : interpolations) {
+            var start = range.getStartOffset();
+            var end = range.getEndOffset();
+            if (start == totalRange.getStartOffset()) {
+                // interpolation at start, insert empty range before to allow editing
+                result.add(new InjectionData(TextRange.create(start, start), null, null));
+            }
+            else if (start > lastEnd) {
+                var prefix = lastEnd > lastStart ? hostText.substring(lastStart, lastEnd) : null;
+                result.add(new InjectionData(TextRange.create(lastEnd, start), prefix, null));
+            }
+            lastStart = start;
+            lastEnd = end;
+        }
+        if (lastEnd < totalRange.getEndOffset()) {
+            var prefix = lastEnd > lastStart ? hostText.substring(lastStart, lastEnd) : null;
+            result.add(new InjectionData(TextRange.create(lastEnd, totalRange.getEndOffset()), prefix, null));
+        }
+        else if (lastEnd == totalRange.getEndOffset() && lastEnd > lastStart) {
+            var prefix = hostText.substring(lastStart, lastEnd);
+            result.add(new InjectionData(TextRange.create(lastEnd, totalRange.getEndOffset()), prefix, null));
+        }
+        return result;
+    }
+}

--- a/src/main/java/dev/monogon/cue/lang/injection/InjectionData.java
+++ b/src/main/java/dev/monogon/cue/lang/injection/InjectionData.java
@@ -1,0 +1,41 @@
+package dev.monogon.cue.lang.injection;
+
+import com.intellij.openapi.util.TextRange;
+
+import java.util.Objects;
+
+class InjectionData {
+    String prefix = null;
+    String suffix = null;
+    TextRange range = null;
+
+    InjectionData(TextRange range, String prefix, String suffix) {
+        this.prefix = prefix;
+        this.suffix = suffix;
+        this.range = range;
+    }
+
+    @Override
+    public String toString() {
+        return "InjectionData{" +
+               "prefix='" + prefix + '\'' +
+               ", suffix='" + suffix + '\'' +
+               ", range=" + range +
+               '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        InjectionData data = (InjectionData)o;
+        return Objects.equals(prefix, data.prefix) &&
+               Objects.equals(suffix, data.suffix) &&
+               Objects.equals(range, data.range);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(prefix, suffix, range);
+    }
+}

--- a/src/main/java/dev/monogon/cue/lang/psi/CueMultilineLiteral.java
+++ b/src/main/java/dev/monogon/cue/lang/psi/CueMultilineLiteral.java
@@ -1,9 +1,4 @@
 package dev.monogon.cue.lang.psi;
 
-import com.intellij.psi.PsiElement;
-
-public interface CueMultilineLiteral extends CueLiteral {
-    PsiElement getLiteralStartElement();
-
-    PsiElement getLiteralEndElement();
+public interface CueMultilineLiteral extends CueStringLiteral {
 }

--- a/src/main/java/dev/monogon/cue/lang/psi/CuePsiElementFactory.java
+++ b/src/main/java/dev/monogon/cue/lang/psi/CuePsiElementFactory.java
@@ -1,0 +1,57 @@
+package dev.monogon.cue.lang.psi;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiFileFactory;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.util.LocalTimeCounter;
+import dev.monogon.cue.lang.CueFileType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class CuePsiElementFactory {
+    private CuePsiElementFactory() {
+    }
+
+    @Nullable
+    public static CueSimpleStringLit createSimpleStringLiteral(@NotNull Project project, @NotNull String unquotedContent, int paddingSize) {
+        var padding = "#".repeat(paddingSize);
+        var text = String.format("%s\"%s\"%s", padding, unquotedContent, padding);
+        var file = PsiFileFactory.getInstance(project).createFileFromText("__.cue", CueFileType.INSTANCE,
+                                                                          text, LocalTimeCounter.currentTime(), true);
+
+        return PsiTreeUtil.getParentOfType(file.findElementAt(1), CueSimpleStringLit.class);
+    }
+
+    @Nullable
+    public static CueMultilineStringLit createMultilineStringLiteral(@NotNull Project project,
+                                                                     @NotNull String unquotedContent,
+                                                                     int paddingSize) {
+        var padding = "#".repeat(paddingSize);
+        var lfContent = unquotedContent.isEmpty() ? "\n" : "\n" + unquotedContent + "\n";
+        var text = String.format("%s\"\"\"%s\"\"\"%s", padding, lfContent, padding);
+        var file = PsiFileFactory.getInstance(project).createFileFromText("__.cue", CueFileType.INSTANCE,
+                                                                          text, LocalTimeCounter.currentTime(), true);
+
+        return PsiTreeUtil.getParentOfType(file.findElementAt(1), CueMultilineStringLit.class);
+    }
+
+    @Nullable
+    public static CueSimpleBytesLit createSimpleBytesLiteral(@NotNull Project project, @NotNull String unquotedContent, int paddingSize) {
+        var padding = "#".repeat(paddingSize);
+        var text = String.format("%s'%s'%s", padding, unquotedContent, padding);
+        var file = PsiFileFactory.getInstance(project).createFileFromText("__.cue", CueFileType.INSTANCE,
+                                                                          text, LocalTimeCounter.currentTime(), true);
+
+        return PsiTreeUtil.getParentOfType(file.findElementAt(1), CueSimpleBytesLit.class);
+    }
+
+    public static CueMultilineBytesLit createMultilineBytesLiteral(Project project, String unquotedContent, int paddingSize) {
+        var padding = "#".repeat(paddingSize);
+        var lfContent = unquotedContent.isEmpty() ? "\n" : "\n" + unquotedContent + "\n";
+        var text = String.format("%s'''%s'''%s", padding, lfContent, padding);
+        var file = PsiFileFactory.getInstance(project).createFileFromText("__.cue", CueFileType.INSTANCE,
+                                                                          text, LocalTimeCounter.currentTime(), true);
+
+        return PsiTreeUtil.getParentOfType(file.findElementAt(1), CueMultilineBytesLit.class);
+    }
+}

--- a/src/main/java/dev/monogon/cue/lang/psi/CueStringLiteral.java
+++ b/src/main/java/dev/monogon/cue/lang/psi/CueStringLiteral.java
@@ -1,0 +1,66 @@
+package dev.monogon.cue.lang.psi;
+
+import com.intellij.openapi.util.TextRange;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.psi.ElementManipulators;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiLanguageInjectionHost;
+import com.intellij.psi.impl.source.tree.LeafPsiElement;
+import dev.monogon.cue.lang.CueTypes;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public interface CueStringLiteral extends CueLiteral, PsiLanguageInjectionHost {
+    boolean isMultilineLiteral();
+
+    @NotNull
+    PsiElement getOpeningQuote();
+
+    @Nullable
+    PsiElement getClosingQuote();
+
+    @Override
+    default PsiLanguageInjectionHost updateText(@NotNull String text) {
+        return ElementManipulators.handleContentChange(this, text);
+    }
+
+    @Override
+    default boolean isValidHost() {
+        if (isMultilineLiteral()) {
+            var opening = getOpeningQuote();
+            var next = opening.getNextSibling();
+            if (!(next instanceof LeafPsiElement) || ((LeafPsiElement)next).getElementType() != CueTypes.NEWLINE) {
+                return false;
+            }
+        }
+        return getClosingQuote() != null;
+    }
+
+    /**
+     * @return range covering the content of the literal, relative to the parent's start offset.
+     */
+    default TextRange getLiteralContentRange() {
+        var openingQuote = getOpeningQuote();
+        var openingNext = openingQuote.getNextSibling();
+        var closingQuote = getClosingQuote();
+        var closingPrev = closingQuote != null ? closingQuote.getPrevSibling() : null;
+        var lf = isMultilineLiteral()
+                 && openingNext instanceof LeafPsiElement
+                 && ((LeafPsiElement)openingNext).getElementType() == CueTypes.NEWLINE
+                 ? 1 : 0;
+        var lfClosing = isMultilineLiteral()
+                        && closingPrev instanceof LeafPsiElement
+                        && ((LeafPsiElement)closingPrev).getElementType() == CueTypes.NEWLINE
+                        && !openingQuote.isEquivalentTo(closingPrev.getPrevSibling())
+                        ? 1 : 0;
+        return TextRange.create(openingQuote.getStartOffsetInParent() + openingQuote.getTextLength() + lf,
+                                closingQuote == null ? getTextLength() : closingQuote.getStartOffsetInParent() - lfClosing);
+    }
+
+    /**
+     * @return The number of #-chars used as escape padding. This is 0 for most literals.
+     */
+    default int getEscapePaddingSize() {
+        return StringUtil.countChars(getOpeningQuote().getText(), '#', 0, true);
+    }
+}

--- a/src/main/java/dev/monogon/cue/lang/psi/CueStringLiteral.java
+++ b/src/main/java/dev/monogon/cue/lang/psi/CueStringLiteral.java
@@ -10,8 +10,13 @@ import dev.monogon.cue.lang.CueTypes;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
+
 public interface CueStringLiteral extends CueLiteral, PsiLanguageInjectionHost {
     boolean isMultilineLiteral();
+
+    @NotNull
+    List<CueInterpolation> getInterpolationList();
 
     @NotNull
     PsiElement getOpeningQuote();

--- a/src/main/java/dev/monogon/cue/lang/psi/CueStringLiteralEscaper.java
+++ b/src/main/java/dev/monogon/cue/lang/psi/CueStringLiteralEscaper.java
@@ -1,13 +1,9 @@
-package dev.monogon.cue.lang.psi.escaper;
+package dev.monogon.cue.lang.psi;
 
 import com.intellij.openapi.util.ProperTextRange;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.LiteralTextEscaper;
-import dev.monogon.cue.lang.psi.CueMultilineBytesLit;
-import dev.monogon.cue.lang.psi.CueMultilineLiteral;
-import dev.monogon.cue.lang.psi.CueSimpleBytesLit;
-import dev.monogon.cue.lang.psi.CueStringLiteral;
-import dev.monogon.cue.lang.util.TextEscaperUtil;
+import dev.monogon.cue.lang.util.CueEscaperUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.atomic.AtomicReference;
@@ -24,10 +20,10 @@ public class CueStringLiteralEscaper extends LiteralTextEscaper<CueStringLiteral
         ProperTextRange.assertProperRange(rangeInsideHost);
 
         var offsetsRef = new AtomicReference<int[]>();
-        var result = TextEscaperUtil.parseLiteral(rangeInsideHost.substring(myHost.getText()),
-                                                  outChars, offsetsRef,
+        var result = CueEscaperUtil.parseLiteral(rangeInsideHost.substring(myHost.getText()),
+                                                 outChars, offsetsRef,
                                                   myHost instanceof CueSimpleBytesLit || myHost instanceof CueMultilineBytesLit,
-                                                  myHost.getEscapePaddingSize());
+                                                 myHost.getEscapePaddingSize());
         decodedOffsets = offsetsRef.get();
         return result;
     }

--- a/src/main/java/dev/monogon/cue/lang/psi/escaper/CueStringLiteralEscaper.java
+++ b/src/main/java/dev/monogon/cue/lang/psi/escaper/CueStringLiteralEscaper.java
@@ -1,0 +1,58 @@
+package dev.monogon.cue.lang.psi.escaper;
+
+import com.intellij.openapi.util.ProperTextRange;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.LiteralTextEscaper;
+import dev.monogon.cue.lang.psi.CueMultilineBytesLit;
+import dev.monogon.cue.lang.psi.CueMultilineLiteral;
+import dev.monogon.cue.lang.psi.CueSimpleBytesLit;
+import dev.monogon.cue.lang.psi.CueStringLiteral;
+import dev.monogon.cue.lang.util.TextEscaperUtil;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+public class CueStringLiteralEscaper extends LiteralTextEscaper<CueStringLiteral> {
+    private int[] decodedOffsets = null;
+
+    public CueStringLiteralEscaper(@NotNull CueStringLiteral host) {
+        super(host);
+    }
+
+    @Override
+    public boolean decode(@NotNull TextRange rangeInsideHost, @NotNull StringBuilder outChars) {
+        ProperTextRange.assertProperRange(rangeInsideHost);
+
+        var offsetsRef = new AtomicReference<int[]>();
+        var result = TextEscaperUtil.parseLiteral(rangeInsideHost.substring(myHost.getText()),
+                                                  outChars, offsetsRef,
+                                                  myHost instanceof CueSimpleBytesLit || myHost instanceof CueMultilineBytesLit,
+                                                  myHost.getEscapePaddingSize());
+        decodedOffsets = offsetsRef.get();
+        return result;
+    }
+
+    @Override
+    public int getOffsetInHost(int offsetInDecoded, @NotNull TextRange rangeInsideHost) {
+        if (offsetInDecoded >= decodedOffsets.length) {
+            return -1;
+        }
+
+        var result = decodedOffsets[offsetInDecoded];
+        if (result == -1) {
+            return -1;
+        }
+
+        return Math.min(result, rangeInsideHost.getLength()) + rangeInsideHost.getStartOffset();
+    }
+
+    @Override
+    public @NotNull TextRange getRelevantTextRange() {
+        return myHost.getLiteralContentRange();
+    }
+
+    @Override
+    public boolean isOneLine() {
+        return !(myHost instanceof CueMultilineLiteral);
+    }
+}

--- a/src/main/java/dev/monogon/cue/lang/psi/impl/CueMultilineBytesLiteralMixin.java
+++ b/src/main/java/dev/monogon/cue/lang/psi/impl/CueMultilineBytesLiteralMixin.java
@@ -1,0 +1,24 @@
+package dev.monogon.cue.lang.psi.impl;
+
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.LiteralTextEscaper;
+import com.intellij.psi.PsiLanguageInjectionHost;
+import dev.monogon.cue.lang.psi.CueMultilineBytesLit;
+import dev.monogon.cue.lang.psi.escaper.CueStringLiteralEscaper;
+import org.jetbrains.annotations.NotNull;
+
+abstract class CueMultilineBytesLiteralMixin extends CueLiteralImpl implements CueMultilineBytesLit {
+    public CueMultilineBytesLiteralMixin(@NotNull ASTNode node) {
+        super(node);
+    }
+
+    @Override
+    public @NotNull LiteralTextEscaper<? extends PsiLanguageInjectionHost> createLiteralTextEscaper() {
+        return new CueStringLiteralEscaper(this);
+    }
+
+    @Override
+    public boolean isMultilineLiteral() {
+        return true;
+    }
+}

--- a/src/main/java/dev/monogon/cue/lang/psi/impl/CueMultilineBytesLiteralMixin.java
+++ b/src/main/java/dev/monogon/cue/lang/psi/impl/CueMultilineBytesLiteralMixin.java
@@ -4,7 +4,7 @@ import com.intellij.lang.ASTNode;
 import com.intellij.psi.LiteralTextEscaper;
 import com.intellij.psi.PsiLanguageInjectionHost;
 import dev.monogon.cue.lang.psi.CueMultilineBytesLit;
-import dev.monogon.cue.lang.psi.escaper.CueStringLiteralEscaper;
+import dev.monogon.cue.lang.psi.CueStringLiteralEscaper;
 import org.jetbrains.annotations.NotNull;
 
 abstract class CueMultilineBytesLiteralMixin extends CueLiteralImpl implements CueMultilineBytesLit {

--- a/src/main/java/dev/monogon/cue/lang/psi/impl/CueMultilineStringLiteralMixin.java
+++ b/src/main/java/dev/monogon/cue/lang/psi/impl/CueMultilineStringLiteralMixin.java
@@ -4,7 +4,7 @@ import com.intellij.lang.ASTNode;
 import com.intellij.psi.LiteralTextEscaper;
 import com.intellij.psi.PsiLanguageInjectionHost;
 import dev.monogon.cue.lang.psi.CueMultilineStringLit;
-import dev.monogon.cue.lang.psi.escaper.CueStringLiteralEscaper;
+import dev.monogon.cue.lang.psi.CueStringLiteralEscaper;
 import org.jetbrains.annotations.NotNull;
 
 abstract class CueMultilineStringLiteralMixin extends CueLiteralImpl implements CueMultilineStringLit {

--- a/src/main/java/dev/monogon/cue/lang/psi/impl/CueMultilineStringLiteralMixin.java
+++ b/src/main/java/dev/monogon/cue/lang/psi/impl/CueMultilineStringLiteralMixin.java
@@ -1,0 +1,24 @@
+package dev.monogon.cue.lang.psi.impl;
+
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.LiteralTextEscaper;
+import com.intellij.psi.PsiLanguageInjectionHost;
+import dev.monogon.cue.lang.psi.CueMultilineStringLit;
+import dev.monogon.cue.lang.psi.escaper.CueStringLiteralEscaper;
+import org.jetbrains.annotations.NotNull;
+
+abstract class CueMultilineStringLiteralMixin extends CueLiteralImpl implements CueMultilineStringLit {
+    public CueMultilineStringLiteralMixin(@NotNull ASTNode node) {
+        super(node);
+    }
+
+    @Override
+    public @NotNull LiteralTextEscaper<? extends PsiLanguageInjectionHost> createLiteralTextEscaper() {
+        return new CueStringLiteralEscaper(this);
+    }
+
+    @Override
+    public boolean isMultilineLiteral() {
+        return true;
+    }
+}

--- a/src/main/java/dev/monogon/cue/lang/psi/impl/CueSimpleByteLiteralMixin.java
+++ b/src/main/java/dev/monogon/cue/lang/psi/impl/CueSimpleByteLiteralMixin.java
@@ -1,0 +1,24 @@
+package dev.monogon.cue.lang.psi.impl;
+
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.LiteralTextEscaper;
+import com.intellij.psi.PsiLanguageInjectionHost;
+import dev.monogon.cue.lang.psi.CueSimpleBytesLit;
+import dev.monogon.cue.lang.psi.escaper.CueStringLiteralEscaper;
+import org.jetbrains.annotations.NotNull;
+
+abstract class CueSimpleByteLiteralMixin extends CueLiteralImpl implements CueSimpleBytesLit {
+    public CueSimpleByteLiteralMixin(@NotNull ASTNode node) {
+        super(node);
+    }
+
+    @Override
+    public @NotNull LiteralTextEscaper<? extends PsiLanguageInjectionHost> createLiteralTextEscaper() {
+        return new CueStringLiteralEscaper(this);
+    }
+
+    @Override
+    public boolean isMultilineLiteral() {
+        return false;
+    }
+}

--- a/src/main/java/dev/monogon/cue/lang/psi/impl/CueSimpleByteLiteralMixin.java
+++ b/src/main/java/dev/monogon/cue/lang/psi/impl/CueSimpleByteLiteralMixin.java
@@ -4,7 +4,7 @@ import com.intellij.lang.ASTNode;
 import com.intellij.psi.LiteralTextEscaper;
 import com.intellij.psi.PsiLanguageInjectionHost;
 import dev.monogon.cue.lang.psi.CueSimpleBytesLit;
-import dev.monogon.cue.lang.psi.escaper.CueStringLiteralEscaper;
+import dev.monogon.cue.lang.psi.CueStringLiteralEscaper;
 import org.jetbrains.annotations.NotNull;
 
 abstract class CueSimpleByteLiteralMixin extends CueLiteralImpl implements CueSimpleBytesLit {

--- a/src/main/java/dev/monogon/cue/lang/psi/impl/CueSimpleStringLiteralMixin.java
+++ b/src/main/java/dev/monogon/cue/lang/psi/impl/CueSimpleStringLiteralMixin.java
@@ -4,7 +4,7 @@ import com.intellij.lang.ASTNode;
 import com.intellij.psi.LiteralTextEscaper;
 import com.intellij.psi.PsiLanguageInjectionHost;
 import dev.monogon.cue.lang.psi.CueSimpleStringLit;
-import dev.monogon.cue.lang.psi.escaper.CueStringLiteralEscaper;
+import dev.monogon.cue.lang.psi.CueStringLiteralEscaper;
 import org.jetbrains.annotations.NotNull;
 
 abstract class CueSimpleStringLiteralMixin extends CueLiteralImpl implements CueSimpleStringLit {

--- a/src/main/java/dev/monogon/cue/lang/psi/impl/CueSimpleStringLiteralMixin.java
+++ b/src/main/java/dev/monogon/cue/lang/psi/impl/CueSimpleStringLiteralMixin.java
@@ -1,0 +1,24 @@
+package dev.monogon.cue.lang.psi.impl;
+
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.LiteralTextEscaper;
+import com.intellij.psi.PsiLanguageInjectionHost;
+import dev.monogon.cue.lang.psi.CueSimpleStringLit;
+import dev.monogon.cue.lang.psi.escaper.CueStringLiteralEscaper;
+import org.jetbrains.annotations.NotNull;
+
+abstract class CueSimpleStringLiteralMixin extends CueLiteralImpl implements CueSimpleStringLit {
+    public CueSimpleStringLiteralMixin(@NotNull ASTNode node) {
+        super(node);
+    }
+
+    @Override
+    public @NotNull LiteralTextEscaper<? extends PsiLanguageInjectionHost> createLiteralTextEscaper() {
+        return new CueStringLiteralEscaper(this);
+    }
+
+    @Override
+    public boolean isMultilineLiteral() {
+        return false;
+    }
+}

--- a/src/main/java/dev/monogon/cue/lang/util/CueEscaperUtil.java
+++ b/src/main/java/dev/monogon/cue/lang/util/CueEscaperUtil.java
@@ -8,14 +8,13 @@ import java.util.concurrent.atomic.AtomicReference;
 /**
  * Helper to handle escaping of string literals.
  */
-final public class TextEscaperUtil {
-    private TextEscaperUtil() {
+final public class CueEscaperUtil {
+    private CueEscaperUtil() {
     }
 
-    // fixme handle unicode escapes
     @NotNull
     public static String escapeCueString(@NotNull String content,
-                                         boolean minimalEscaping, boolean escapeLinefeeds,
+                                         boolean minimalEscaping, boolean escapeLinefeeds, boolean escapeInterpolation,
                                          boolean escapeSingleQuote, boolean escapeDoubleQuote,
                                          boolean tripleSingleQuoted, boolean tripleDoubleQuoted,
                                          int escapePaddingSize) {
@@ -24,8 +23,12 @@ final public class TextEscaperUtil {
 
         char[] chars = content.toCharArray();
         for (int i = 0; i < chars.length; i++) {
-            char c = chars[i];
+            final char c = chars[i];
+
             if (c == '\\' && isEscapePrefix(content, i, escapePaddingSize)) {
+                if (escapeInterpolation && i + escapePaddingSize + 1 < chars.length && chars[i + escapePaddingSize + 1] == '(') {
+                    out.append(backslash);
+                }
                 out.append('\\');
                 continue;
             }
@@ -82,10 +85,6 @@ final public class TextEscaperUtil {
                         out.append(backslash);
                     }
                     out.append('/');
-                    break;
-                case '\\':
-                    out.append(backslash);
-                    out.append('\\');
                     break;
                 case '\'':
                     if (!minimalEscaping || escapeSingleQuote) {

--- a/src/main/java/dev/monogon/cue/lang/util/TextEscaperUtil.java
+++ b/src/main/java/dev/monogon/cue/lang/util/TextEscaperUtil.java
@@ -1,0 +1,286 @@
+package dev.monogon.cue.lang.util;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Helper to handle escaping of string literals.
+ */
+final public class TextEscaperUtil {
+    private TextEscaperUtil() {
+    }
+
+    // fixme handle unicode escapes
+    @NotNull
+    public static String escapeCueString(@NotNull String content,
+                                         boolean minimalEscaping, boolean escapeLinefeeds,
+                                         boolean escapeSingleQuote, boolean escapeDoubleQuote,
+                                         boolean tripleSingleQuoted, boolean tripleDoubleQuoted,
+                                         int escapePaddingSize) {
+        var backslash = "\\" + "#".repeat(escapePaddingSize);
+        var out = new StringBuilder();
+
+        char[] chars = content.toCharArray();
+        for (int i = 0; i < chars.length; i++) {
+            char c = chars[i];
+            if (c == '\\' && isEscapePrefix(content, i, escapePaddingSize)) {
+                out.append('\\');
+                continue;
+            }
+
+            if (c == '\"' && tripleSingleQuoted && hasPrefix(content, i, "'''")) {
+                out.append("\\'");
+                continue;
+            }
+
+            if (c == '"' && tripleDoubleQuoted && hasPrefix(content, i, "\"\"\"")) {
+                out.append("\\\"");
+                continue;
+            }
+
+            switch (c) {
+                case (char)7: // <bell>
+                    out.append(backslash).append("a");
+                    break;
+                case '\b': // <backspace>
+                    out.append(backslash).append("b");
+                    break;
+                case '\f': // form feed
+                    out.append(backslash).append("f");
+                    break;
+                case '\n': // line feed
+                    if (escapeLinefeeds) {
+                        out.append(backslash).append("n");
+                    }
+                    else {
+                        out.append("\n");
+                    }
+                    break;
+                case '\r': // carriage return
+                    out.append(backslash).append("r");
+                    break;
+                case '\t': // tab
+                    if (minimalEscaping) {
+                        out.append('\t');
+                    }
+                    else {
+                        out.append(backslash).append("t");
+                    }
+                    break;
+                case (char)11: // vertical tab
+                    if (minimalEscaping) {
+                        out.append((char)11);
+                    }
+                    else {
+                        out.append(backslash).append("v");
+                    }
+                    break;
+                case '/':
+                    if (!minimalEscaping) {
+                        out.append(backslash);
+                    }
+                    out.append('/');
+                    break;
+                case '\\':
+                    out.append(backslash);
+                    out.append('\\');
+                    break;
+                case '\'':
+                    if (!minimalEscaping || escapeSingleQuote) {
+                        out.append(backslash);
+                    }
+                    out.append('\'');
+                    break;
+                case '"':
+                    if (!minimalEscaping || escapeDoubleQuote) {
+                        out.append(backslash);
+                    }
+                    out.append('"');
+                    break;
+                default: // insert as-is, optionally unicode-encoded
+                    if (c < 255 || minimalEscaping) {
+                        out.append(c);
+                    }
+                    else if (c < 65535) { // 0xFFFF
+                        out.append(backslash).append("u").append(String.format("%04x", (int)c));
+                    }
+                    else {
+                        out.append(backslash).append("U").append(String.format("%08x", (int)c));
+                    }
+                    break;
+            }
+        }
+        return out.toString();
+    }
+
+    /**
+     * @param content           content to be decoded
+     * @param out               where the decoded characters are appended
+     * @param decodedOffsetsRef will be updated with the new decoded offsets
+     * @param allowByteEscapes  if octal and hex byte escapes are allowed
+     * @return if the decode operation was successful
+     */
+    // fixme handle unicode, octal, etc. escapes
+    public static boolean parseLiteral(@NotNull CharSequence content,
+                                       @NotNull StringBuilder out,
+                                       @NotNull AtomicReference<int[]> decodedOffsetsRef,
+                                       boolean allowByteEscapes,
+                                       int escapePaddingSize) {
+        var length = content.length();
+        var offsets = new int[length + 1];
+        decodedOffsetsRef.set(offsets);
+        // reset to -1, i.e. out-of-range
+        Arrays.fill(offsets, -1);
+
+        // handle escapes
+        final var outOffset = out.length();
+        int i = 0;
+        while (i < length) {
+            var c = content.charAt(i);
+            offsets[out.length() - outOffset] = i;
+            offsets[out.length() - outOffset + 1] = i + 1;
+
+            // not escaped
+            if (!isEscapePrefix(content, i, escapePaddingSize)) {
+                i++;
+                out.append(c);
+                continue;
+            }
+
+            // skip backslash and padding
+            i++;
+            i += escapePaddingSize;
+
+            // incomplete escape
+            if (i == content.length()) {
+                return false;
+            }
+
+            // c is now the char after \ and padding chars
+            c = content.charAt(i);
+            i++;
+
+            if (c == 'u' || c == 'U') {
+                // 4-digit or 8-digit unicode escape
+                var digits = c == 'u' ? 4 : 8;
+                if (i + digits <= content.length()) {
+                    var escaped = content.subSequence(i, i + digits);
+                    try {
+                        out.appendCodePoint(Integer.parseInt(escaped.toString(), 16));
+                        i += digits;
+                        continue;
+                    }
+                    catch (NumberFormatException e) {
+                        return false;
+                    }
+                }
+            }
+            else if (allowByteEscapes && c == 'x') { // 2-digit hex escape of a byte in byte literal
+                if (i + 2 <= content.length()) {
+                    var escaped = content.subSequence(i, i + 2);
+                    try {
+                        out.append((char)Integer.parseInt(escaped.toString(), 16));
+                        i += 2;
+                        continue;
+                    }
+                    catch (NumberFormatException e) {
+                        return false;
+                    }
+                }
+            }
+            else if (allowByteEscapes && isOctalEscapeValue(content, i - 1)) { // octal escape in byte literal
+                if (i + 2 <= content.length()) {
+                    var escaped = content.subSequence(i - 1, i + 2);
+                    try {
+                        out.append((char)Integer.parseInt(escaped.toString(), 8));
+                        i += 2;
+                        continue;
+                    }
+                    catch (NumberFormatException e) {
+                        return false;
+                    }
+                }
+            }
+
+            switch (c) {
+                case 'a':
+                    out.append((char)7);
+                    break;
+                case 'b':
+                    out.append('\b');
+                    break;
+                case 'f':
+                    out.append('\f');
+                    break;
+                case 'n':
+                    out.append('\n');
+                    break;
+                case 'r':
+                    out.append('\r');
+                    break;
+                case 't':
+                    out.append('\t');
+                    break;
+                case 'v': // vertical tab
+                    out.append((char)11);
+                    break;
+                // remaining inserted as-is
+                case '/':
+                case '\\':
+                case '\'':
+                case '"':
+                    out.append(c);
+                    break;
+                default:
+                    // unknown escape
+                    out.append('\\');
+                    out.append(c);
+                    break;
+            }
+            offsets[out.length() - outOffset] = i;
+        }
+        return true;
+    }
+
+    /**
+     * @return true if the next three characters are a valid value of an octal escape
+     */
+    private static boolean isOctalEscapeValue(@NotNull CharSequence chars, int index) {
+        if (chars.length() < index + 3) {
+            return false;
+        }
+
+        for (int i = 1; i < 3; i++) {
+            var c = chars.charAt(index + i);
+            if (c < '0' || c > '7') {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static boolean isEscapePrefix(@NotNull CharSequence chars, int index, int paddingSize) {
+        if (chars.charAt(index) != '\\') {
+            return false;
+        }
+
+        for (int i = 0; i < paddingSize; i++) {
+            var at = index + i + 1;
+            if (at >= chars.length() || chars.charAt(at) != '#') {
+                return false;
+            }
+        }
+
+        // escaped char must not be a #
+        return chars.length() > index + paddingSize + 1 && chars.charAt(index + paddingSize + 1) != '#';
+    }
+
+    public static boolean hasPrefix(@NotNull String chars, int index, @NotNull String expected) {
+        if (chars.length() < index + expected.length()) {
+            return false;
+        }
+        return expected.equals(chars.substring(index, index + expected.length()));
+    }
+}

--- a/src/main/resources/META-INF/intellilang.xml
+++ b/src/main/resources/META-INF/intellilang.xml
@@ -1,0 +1,6 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <multiHostInjector order="first, before TemporaryPlacesInjector"
+                           implementation="dev.monogon.cue.lang.injection.CueMultiHostInjector"/>
+    </extensions>
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -12,6 +12,15 @@
         <lang.parserDefinition language="CUE" implementationClass="dev.monogon.cue.lang.CueParserDefinition"/>
         <fileType name="CUE" language="CUE" extensions="cue" implementationClass="dev.monogon.cue.lang.CueFileType"/>
 
+        <lang.elementManipulator forClass="dev.monogon.cue.lang.psi.CueSimpleStringLit"
+                                 implementationClass="dev.monogon.cue.lang.elementManipulator.CueSimpleStringElementManipulator"/>
+        <lang.elementManipulator forClass="dev.monogon.cue.lang.psi.CueSimpleBytesLit"
+                                 implementationClass="dev.monogon.cue.lang.elementManipulator.CueSimpleBytesElementManipulator"/>
+        <lang.elementManipulator forClass="dev.monogon.cue.lang.psi.CueMultilineStringLit"
+                                 implementationClass="dev.monogon.cue.lang.elementManipulator.CueMultilineStringElementManipulator"/>
+        <lang.elementManipulator forClass="dev.monogon.cue.lang.psi.CueMultilineBytesLit"
+                                 implementationClass="dev.monogon.cue.lang.elementManipulator.CueMultilineBytesElementManipulator"/>
+
         <lang.syntaxHighlighter language="CUE" implementationClass="dev.monogon.cue.lang.highlighter.CueSyntaxHighlighter"/>
         <annotator language="CUE" implementationClass="dev.monogon.cue.lang.annotator.CueAnnotator"/>
         <colorSettingsPage implementation="dev.monogon.cue.lang.highlighter.CueColorSettingsPage"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -7,6 +7,7 @@
     <!-- Product and plugin compatibility requirements -->
     <!-- https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html -->
     <depends>com.intellij.modules.platform</depends>
+    <depends optional="true" config-file="intellilang.xml">org.intellij.intelliLang</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <lang.parserDefinition language="CUE" implementationClass="dev.monogon.cue.lang.CueParserDefinition"/>

--- a/src/test/java/dev/monogon/cue/lang/injection/CueMultiHostInjectorTest.java
+++ b/src/test/java/dev/monogon/cue/lang/injection/CueMultiHostInjectorTest.java
@@ -1,0 +1,70 @@
+package dev.monogon.cue.lang.injection;
+
+import com.intellij.openapi.util.TextRange;
+import dev.monogon.cue.CueLightTest;
+import dev.monogon.cue.lang.psi.CueSimpleBytesLit;
+import dev.monogon.cue.lang.psi.CueStringLiteral;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+public class CueMultiHostInjectorTest extends CueLightTest {
+    @Test
+    public void singleRange() {
+        myFixture.configureByText("a.cue", "'cont<caret>ent'");
+        var literal = findTypedElement(CueSimpleBytesLit.class);
+        var ranges = CueMultiHostInjector.findInjectionRanges(literal);
+        assertEquals(Collections.singletonList(new InjectionData(TextRange.create(1, 8), null, null)), ranges);
+    }
+
+    @Test
+    public void interpolationMiddle() {
+        myFixture.configureByText("a.cue", "'a\\(123)b'");
+        var literal = findTypedElement(CueStringLiteral.class);
+        var ranges = CueMultiHostInjector.findInjectionRanges(literal);
+
+        var expected = Arrays.asList(
+            new InjectionData(TextRange.create(1, 2), null, null),
+            new InjectionData(TextRange.create(8, 9), "\\(123)", null));
+        assertEquals(expected, ranges);
+    }
+
+    @Test
+    public void interpolationFirst() {
+        myFixture.configureByText("a.cue", "'\\(123)b'");
+        var literal = findTypedElement(CueStringLiteral.class);
+        var ranges = CueMultiHostInjector.findInjectionRanges(literal);
+
+        var expected = Arrays.asList(
+            new InjectionData(TextRange.create(1, 1), null, null),
+            new InjectionData(TextRange.create(7, 8), "\\(123)", null));
+        assertEquals(expected, ranges);
+    }
+
+    @Test
+    public void interpolationEnd() {
+        myFixture.configureByText("a.cue", "'a\\(123)'");
+        var literal = findTypedElement(CueStringLiteral.class);
+        var ranges = CueMultiHostInjector.findInjectionRanges(literal);
+
+        var expected = Arrays.asList(
+            new InjectionData(TextRange.create(1, 2), null, null),
+            new InjectionData(TextRange.create(8, 8), "\\(123)", null));
+        assertEquals(expected, ranges);
+    }
+
+    @Test
+    public void interpolationMultiple() {
+        myFixture.configureByText("a.cue", "'a\\(1)b\\(2)b\\(3)'");
+        var literal = findTypedElement(CueStringLiteral.class);
+        var ranges = CueMultiHostInjector.findInjectionRanges(literal);
+
+        var expected = Arrays.asList(
+            new InjectionData(TextRange.create(1, 2), null, null),
+            new InjectionData(TextRange.create(6, 7), "\\(1)", null),
+            new InjectionData(TextRange.create(11, 12), "\\(2)", null),
+            new InjectionData(TextRange.create(16, 16), "\\(3)", null));
+        assertEquals(expected, ranges);
+    }
+}

--- a/src/test/java/dev/monogon/cue/lang/psi/CuePsiElementFactoryTest.java
+++ b/src/test/java/dev/monogon/cue/lang/psi/CuePsiElementFactoryTest.java
@@ -1,0 +1,42 @@
+package dev.monogon.cue.lang.psi;
+
+import dev.monogon.cue.CueLightTest;
+import org.junit.Test;
+
+public class CuePsiElementFactoryTest extends CueLightTest {
+    @Test
+    public void simpleString() {
+        var string = CuePsiElementFactory.createSimpleStringLiteral(getProject(), "my content", 0);
+        assertEquals("\"my content\"", string.getText());
+
+        string = CuePsiElementFactory.createSimpleStringLiteral(getProject(), "my content", 1);
+        assertEquals("#\"my content\"#", string.getText());
+    }
+
+    @Test
+    public void multilineString() {
+        var string = CuePsiElementFactory.createMultilineStringLiteral(getProject(), "my content", 0);
+        assertEquals("\"\"\"\nmy content\n\"\"\"", string.getText());
+
+        string = CuePsiElementFactory.createMultilineStringLiteral(getProject(), "my content", 1);
+        assertEquals("#\"\"\"\nmy content\n\"\"\"#", string.getText());
+    }
+
+    @Test
+    public void simpleBytes() {
+        var bytes = CuePsiElementFactory.createSimpleBytesLiteral(getProject(), "my content", 0);
+        assertEquals("'my content'", bytes.getText());
+
+        bytes = CuePsiElementFactory.createSimpleBytesLiteral(getProject(), "my content", 1);
+        assertEquals("#'my content'#", bytes.getText());
+    }
+
+    @Test
+    public void multilineBytes() {
+        var bytes = CuePsiElementFactory.createMultilineBytesLiteral(getProject(), "my content", 0);
+        assertEquals("'''\nmy content\n'''", bytes.getText());
+
+        bytes = CuePsiElementFactory.createMultilineBytesLiteral(getProject(), "my content", 1);
+        assertEquals("#'''\nmy content\n'''#", bytes.getText());
+    }
+}

--- a/src/test/java/dev/monogon/cue/lang/psi/escaper/TextEscaperUtilTest.java
+++ b/src/test/java/dev/monogon/cue/lang/psi/escaper/TextEscaperUtilTest.java
@@ -1,0 +1,196 @@
+package dev.monogon.cue.lang.psi.escaper;
+
+import dev.monogon.cue.lang.util.TextEscaperUtil;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.*;
+
+public class TextEscaperUtilTest {
+    @Test
+    public void noEscaped() {
+        StringBuilder out = new StringBuilder();
+        var offsetsRef = new AtomicReference<int[]>();
+        var ok = TextEscaperUtil.parseLiteral("abc", out, offsetsRef, false, 0);
+        assertTrue(ok);
+
+        var offsets = offsetsRef.get();
+        assertNotNull(offsets);
+        assertEquals(0, offsets[0]);
+        assertEquals(1, offsets[1]);
+        assertEquals(2, offsets[2]);
+        // out-of-range of original, case handled by caller
+        assertEquals(3, offsets[3]);
+
+        assertEquals("abc", out.toString());
+    }
+
+    @Test
+    public void simpleEscaped() {
+        StringBuilder out = new StringBuilder();
+        var offsetsRef = new AtomicReference<int[]>();
+        var ok = TextEscaperUtil.parseLiteral("a\\ac", out, offsetsRef, false, 0);
+        assertTrue(ok);
+
+        var offsets = offsetsRef.get();
+        assertNotNull(offsets);
+        assertEquals(0, offsets[0]); //a
+        assertEquals(1, offsets[1]); //<bell>
+        assertEquals(3, offsets[2]); //c
+        // out-of-range of original, case handled by caller
+        assertEquals(4, offsets[3]);
+
+        assertEquals("a\u0007c", out.toString());
+    }
+
+    @Test
+    public void simpleEscapedPadded() {
+        StringBuilder out = new StringBuilder();
+        var offsetsRef = new AtomicReference<int[]>();
+        var ok = TextEscaperUtil.parseLiteral("a\\##ac", out, offsetsRef, false, 2);
+        assertTrue(ok);
+
+        var offsets = offsetsRef.get();
+        assertNotNull(offsets);
+        assertEquals(0, offsets[0]); //a
+        assertEquals(1, offsets[1]); //<bell>
+        assertEquals(5, offsets[2]); //c
+        // out-of-range of original, case handled by caller
+        assertEquals(6, offsets[3]);
+
+        assertEquals("a\u0007c", out.toString());
+    }
+
+    @Test
+    public void unicodeEscaped4Digit() {
+        StringBuilder out = new StringBuilder();
+        var offsetsRef = new AtomicReference<int[]>();
+        var ok = TextEscaperUtil.parseLiteral("\\u65e5\\u672c\\u8a9e", out, offsetsRef, false, 0);
+        assertTrue(ok);
+
+        var offsets = offsetsRef.get();
+        assertNotNull(offsets);
+        assertEquals(0, offsets[0]);
+        assertEquals(6, offsets[1]);
+        assertEquals(12, offsets[2]);
+        // out-of-range of original, case handled by caller
+        assertEquals(13, offsets[3]);
+
+        assertEquals("日本語", out.toString());
+    }
+
+    @Test
+    public void unicodeEscaped8Digit() {
+        StringBuilder out = new StringBuilder();
+        var offsetsRef = new AtomicReference<int[]>();
+        var ok = TextEscaperUtil.parseLiteral("\\U000065e5\\U0000672c\\U00008a9e", out, offsetsRef, false, 0);
+        assertTrue(ok);
+
+        var offsets = offsetsRef.get();
+        assertNotNull(offsets);
+        assertEquals(0, offsets[0]);
+        assertEquals(10, offsets[1]);
+        assertEquals(20, offsets[2]);
+        // out-of-range of original, case handled by caller
+        assertEquals(21, offsets[3]);
+
+        assertEquals("日本語", out.toString());
+    }
+
+    @Test
+    public void byteHexEscaping() {
+        StringBuilder out = new StringBuilder();
+        var offsetsRef = new AtomicReference<int[]>();
+        var ok = TextEscaperUtil.parseLiteral("\\x30\\x31\\x32", out, offsetsRef, true, 0);
+        assertTrue(ok);
+
+        var offsets = offsetsRef.get();
+        assertNotNull(offsets);
+        assertEquals(0, offsets[0]);
+        assertEquals(4, offsets[1]);
+        assertEquals(8, offsets[2]);
+        // out-of-range of original, case handled by caller
+        assertEquals(9, offsets[3]);
+
+        assertEquals("012", out.toString());
+    }
+
+    @Test
+    public void byteOctalEscaping() {
+        StringBuilder out = new StringBuilder();
+        var offsetsRef = new AtomicReference<int[]>();
+        var ok = TextEscaperUtil.parseLiteral("\\060\\061\\062", out, offsetsRef, true, 0);
+        assertTrue(ok);
+
+        var offsets = offsetsRef.get();
+        assertNotNull(offsets);
+        assertEquals(0, offsets[0]);
+        assertEquals(4, offsets[1]);
+        assertEquals(8, offsets[2]);
+        // out-of-range of original, case handled by caller
+        assertEquals(9, offsets[3]);
+
+        assertEquals("012", out.toString());
+    }
+
+    @Test
+    public void allEscaped() {
+        StringBuilder out = new StringBuilder();
+        var offsetsRef = new AtomicReference<int[]>();
+        var ok = TextEscaperUtil.parseLiteral("\\a\\b\\'", out, offsetsRef, false, 0);
+        assertTrue(ok);
+
+        var offsets = offsetsRef.get();
+        assertNotNull(offsets);
+        assertEquals(0, offsets[0]); //<bell>
+        assertEquals(2, offsets[1]); //<backspace>
+        assertEquals(4, offsets[2]); //'
+        // out-of-range of original, case handled by caller
+        assertEquals(6, offsets[3]);
+
+        assertEquals("\u0007\b'", out.toString());
+    }
+
+    @Test
+    public void escapeSimpleString() {
+        assertEquals("abc", TextEscaperUtil.escapeCueString("abc", false, true, true, true, false, false, 0));
+        assertEquals("abc", TextEscaperUtil.escapeCueString("abc", false, true, true, true, false, false, 10));
+
+        assertEquals("\\b", TextEscaperUtil.escapeCueString("\b", false, true, true, true, false, false, 0));
+        assertEquals("\\#b", TextEscaperUtil.escapeCueString("\b", false, true, true, true, false, false, 1));
+        assertEquals("\\###b", TextEscaperUtil.escapeCueString("\b", false, true, true, true, false, false, 3));
+
+        assertEquals("a\\bc", TextEscaperUtil.escapeCueString("a\bc", false, true, true, true, false, false, 0));
+
+        // tab
+        assertEquals("a\tc", TextEscaperUtil.escapeCueString("a\tc", true, true, true, true, false, false, 0));
+        assertEquals("a\\tc", TextEscaperUtil.escapeCueString("a\tc", false, true, true, true, false, false, 0));
+    }
+
+    @Test
+    public void escapeUnicode() {
+        assertEquals("日本語", TextEscaperUtil.escapeCueString("日本語", true, true, true, true, false, false, 0));
+        assertEquals("\\u65e5\\u672c\\u8a9e", TextEscaperUtil.escapeCueString("日本語", false, true, true, true, false,
+                                                                              false, 0));
+    }
+
+    @Test
+    public void escapeAlreadyEscaped() {
+        assertEquals("\\a", TextEscaperUtil.escapeCueString("\\a", true, true, true, true, false, false, 0));
+        assertEquals("a\\ab", TextEscaperUtil.escapeCueString("a\\ab", true, true, true, true, false, false, 0));
+    }
+
+    @Test
+    public void escapePrefix() {
+        assertTrue(TextEscaperUtil.isEscapePrefix("a\\tbc", 1, 0));
+        assertTrue(TextEscaperUtil.isEscapePrefix("a\\#tbc", 1, 1));
+        assertTrue(TextEscaperUtil.isEscapePrefix("a\\##tbc", 1, 2));
+        assertTrue(TextEscaperUtil.isEscapePrefix("a\\###tbc", 1, 3));
+
+        assertFalse(TextEscaperUtil.isEscapePrefix("a\\#tbc", 1, 0));
+        assertFalse(TextEscaperUtil.isEscapePrefix("a\\##tbc", 1, 1));
+        assertFalse(TextEscaperUtil.isEscapePrefix("a\\###tbc", 1, 2));
+        assertFalse(TextEscaperUtil.isEscapePrefix("a\\####tbc", 1, 3));
+    }
+}

--- a/src/test/java/dev/monogon/cue/lang/psi/escaper/TextEscaperUtilTest.java
+++ b/src/test/java/dev/monogon/cue/lang/psi/escaper/TextEscaperUtilTest.java
@@ -1,6 +1,6 @@
 package dev.monogon.cue.lang.psi.escaper;
 
-import dev.monogon.cue.lang.util.TextEscaperUtil;
+import dev.monogon.cue.lang.util.CueEscaperUtil;
 import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicReference;
@@ -12,7 +12,7 @@ public class TextEscaperUtilTest {
     public void noEscaped() {
         StringBuilder out = new StringBuilder();
         var offsetsRef = new AtomicReference<int[]>();
-        var ok = TextEscaperUtil.parseLiteral("abc", out, offsetsRef, false, 0);
+        var ok = CueEscaperUtil.parseLiteral("abc", out, offsetsRef, false, 0);
         assertTrue(ok);
 
         var offsets = offsetsRef.get();
@@ -30,7 +30,7 @@ public class TextEscaperUtilTest {
     public void simpleEscaped() {
         StringBuilder out = new StringBuilder();
         var offsetsRef = new AtomicReference<int[]>();
-        var ok = TextEscaperUtil.parseLiteral("a\\ac", out, offsetsRef, false, 0);
+        var ok = CueEscaperUtil.parseLiteral("a\\ac", out, offsetsRef, false, 0);
         assertTrue(ok);
 
         var offsets = offsetsRef.get();
@@ -48,7 +48,7 @@ public class TextEscaperUtilTest {
     public void simpleEscapedPadded() {
         StringBuilder out = new StringBuilder();
         var offsetsRef = new AtomicReference<int[]>();
-        var ok = TextEscaperUtil.parseLiteral("a\\##ac", out, offsetsRef, false, 2);
+        var ok = CueEscaperUtil.parseLiteral("a\\##ac", out, offsetsRef, false, 2);
         assertTrue(ok);
 
         var offsets = offsetsRef.get();
@@ -66,7 +66,7 @@ public class TextEscaperUtilTest {
     public void unicodeEscaped4Digit() {
         StringBuilder out = new StringBuilder();
         var offsetsRef = new AtomicReference<int[]>();
-        var ok = TextEscaperUtil.parseLiteral("\\u65e5\\u672c\\u8a9e", out, offsetsRef, false, 0);
+        var ok = CueEscaperUtil.parseLiteral("\\u65e5\\u672c\\u8a9e", out, offsetsRef, false, 0);
         assertTrue(ok);
 
         var offsets = offsetsRef.get();
@@ -84,7 +84,7 @@ public class TextEscaperUtilTest {
     public void unicodeEscaped8Digit() {
         StringBuilder out = new StringBuilder();
         var offsetsRef = new AtomicReference<int[]>();
-        var ok = TextEscaperUtil.parseLiteral("\\U000065e5\\U0000672c\\U00008a9e", out, offsetsRef, false, 0);
+        var ok = CueEscaperUtil.parseLiteral("\\U000065e5\\U0000672c\\U00008a9e", out, offsetsRef, false, 0);
         assertTrue(ok);
 
         var offsets = offsetsRef.get();
@@ -102,7 +102,7 @@ public class TextEscaperUtilTest {
     public void byteHexEscaping() {
         StringBuilder out = new StringBuilder();
         var offsetsRef = new AtomicReference<int[]>();
-        var ok = TextEscaperUtil.parseLiteral("\\x30\\x31\\x32", out, offsetsRef, true, 0);
+        var ok = CueEscaperUtil.parseLiteral("\\x30\\x31\\x32", out, offsetsRef, true, 0);
         assertTrue(ok);
 
         var offsets = offsetsRef.get();
@@ -120,7 +120,7 @@ public class TextEscaperUtilTest {
     public void byteOctalEscaping() {
         StringBuilder out = new StringBuilder();
         var offsetsRef = new AtomicReference<int[]>();
-        var ok = TextEscaperUtil.parseLiteral("\\060\\061\\062", out, offsetsRef, true, 0);
+        var ok = CueEscaperUtil.parseLiteral("\\060\\061\\062", out, offsetsRef, true, 0);
         assertTrue(ok);
 
         var offsets = offsetsRef.get();
@@ -138,7 +138,7 @@ public class TextEscaperUtilTest {
     public void allEscaped() {
         StringBuilder out = new StringBuilder();
         var offsetsRef = new AtomicReference<int[]>();
-        var ok = TextEscaperUtil.parseLiteral("\\a\\b\\'", out, offsetsRef, false, 0);
+        var ok = CueEscaperUtil.parseLiteral("\\a\\b\\'", out, offsetsRef, false, 0);
         assertTrue(ok);
 
         var offsets = offsetsRef.get();
@@ -154,43 +154,46 @@ public class TextEscaperUtilTest {
 
     @Test
     public void escapeSimpleString() {
-        assertEquals("abc", TextEscaperUtil.escapeCueString("abc", false, true, true, true, false, false, 0));
-        assertEquals("abc", TextEscaperUtil.escapeCueString("abc", false, true, true, true, false, false, 10));
+        assertEquals("abc", CueEscaperUtil.escapeCueString("abc", false, true, true, true, true, false, false, 0));
+        assertEquals("abc", CueEscaperUtil.escapeCueString("abc", false, true, true, true, true, false, false, 10));
 
-        assertEquals("\\b", TextEscaperUtil.escapeCueString("\b", false, true, true, true, false, false, 0));
-        assertEquals("\\#b", TextEscaperUtil.escapeCueString("\b", false, true, true, true, false, false, 1));
-        assertEquals("\\###b", TextEscaperUtil.escapeCueString("\b", false, true, true, true, false, false, 3));
+        assertEquals("\\b", CueEscaperUtil.escapeCueString("\b", false, true, true, true, true, false, false, 0));
+        assertEquals("\\#b", CueEscaperUtil.escapeCueString("\b", false, true, true, true, true, false, false, 1));
+        assertEquals("\\###b", CueEscaperUtil.escapeCueString("\b", false, true, true, true, true, false, false, 3));
 
-        assertEquals("a\\bc", TextEscaperUtil.escapeCueString("a\bc", false, true, true, true, false, false, 0));
+        assertEquals("a\\bc", CueEscaperUtil.escapeCueString("a\bc", false, true, true, true, true, false, false, 0));
 
         // tab
-        assertEquals("a\tc", TextEscaperUtil.escapeCueString("a\tc", true, true, true, true, false, false, 0));
-        assertEquals("a\\tc", TextEscaperUtil.escapeCueString("a\tc", false, true, true, true, false, false, 0));
+        assertEquals("a\tc", CueEscaperUtil.escapeCueString("a\tc", true, true, true, true, true, false, false, 0));
+        assertEquals("a\\tc", CueEscaperUtil.escapeCueString("a\tc", false, true, true, true, true, false, false, 0));
     }
 
     @Test
     public void escapeUnicode() {
-        assertEquals("日本語", TextEscaperUtil.escapeCueString("日本語", true, true, true, true, false, false, 0));
-        assertEquals("\\u65e5\\u672c\\u8a9e", TextEscaperUtil.escapeCueString("日本語", false, true, true, true, false,
-                                                                              false, 0));
+        assertEquals("日本語", CueEscaperUtil.escapeCueString("日本語", true, true, true, true, true, false, false, 0));
+        assertEquals("\\u65e5\\u672c\\u8a9e", CueEscaperUtil.escapeCueString("日本語", false, true, true, true, true, false,
+                                                                             false, 0));
     }
 
     @Test
     public void escapeAlreadyEscaped() {
-        assertEquals("\\a", TextEscaperUtil.escapeCueString("\\a", true, true, true, true, false, false, 0));
-        assertEquals("a\\ab", TextEscaperUtil.escapeCueString("a\\ab", true, true, true, true, false, false, 0));
+        assertEquals("\\a", CueEscaperUtil.escapeCueString("\\a", true, true, false, true, true, false, false, 0));
+        assertEquals("\\a", CueEscaperUtil.escapeCueString("\\a", true, true, true, true, true, false, false, 0));
+
+        assertEquals("a\\ab", CueEscaperUtil.escapeCueString("a\\ab", true, true, false, true, true, false, false, 0));
+        assertEquals("a\\ab", CueEscaperUtil.escapeCueString("a\\ab", true, true, true, true, true, false, false, 0));
     }
 
     @Test
     public void escapePrefix() {
-        assertTrue(TextEscaperUtil.isEscapePrefix("a\\tbc", 1, 0));
-        assertTrue(TextEscaperUtil.isEscapePrefix("a\\#tbc", 1, 1));
-        assertTrue(TextEscaperUtil.isEscapePrefix("a\\##tbc", 1, 2));
-        assertTrue(TextEscaperUtil.isEscapePrefix("a\\###tbc", 1, 3));
+        assertTrue(CueEscaperUtil.isEscapePrefix("a\\tbc", 1, 0));
+        assertTrue(CueEscaperUtil.isEscapePrefix("a\\#tbc", 1, 1));
+        assertTrue(CueEscaperUtil.isEscapePrefix("a\\##tbc", 1, 2));
+        assertTrue(CueEscaperUtil.isEscapePrefix("a\\###tbc", 1, 3));
 
-        assertFalse(TextEscaperUtil.isEscapePrefix("a\\#tbc", 1, 0));
-        assertFalse(TextEscaperUtil.isEscapePrefix("a\\##tbc", 1, 1));
-        assertFalse(TextEscaperUtil.isEscapePrefix("a\\###tbc", 1, 2));
-        assertFalse(TextEscaperUtil.isEscapePrefix("a\\####tbc", 1, 3));
+        assertFalse(CueEscaperUtil.isEscapePrefix("a\\#tbc", 1, 0));
+        assertFalse(CueEscaperUtil.isEscapePrefix("a\\##tbc", 1, 1));
+        assertFalse(CueEscaperUtil.isEscapePrefix("a\\###tbc", 1, 2));
+        assertFalse(CueEscaperUtil.isEscapePrefix("a\\####tbc", 1, 3));
     }
 }

--- a/src/test/java/dev/monogon/cue/lang/psi/impl/CueMultilineBytesLiteralMixinTest.java
+++ b/src/test/java/dev/monogon/cue/lang/psi/impl/CueMultilineBytesLiteralMixinTest.java
@@ -1,0 +1,104 @@
+package dev.monogon.cue.lang.psi.impl;
+
+import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.util.Computable;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiLanguageInjectionHost;
+import dev.monogon.cue.CueLightTest;
+import dev.monogon.cue.lang.psi.CueMultilineBytesLit;
+import org.junit.Test;
+
+public class CueMultilineBytesLiteralMixinTest extends CueLightTest {
+    @Test
+    public void contentRange() {
+        myFixture.configureByText("a.cue", "'''content<caret>'''");
+        var string = findTypedElement(CueMultilineBytesLit.class);
+        assertEquals(TextRange.create(3, 10), string.getLiteralContentRange());
+    }
+
+    @Test
+    public void contentRangeEmpty() {
+        myFixture.configureByText("a.cue", "'''\n'''");
+        var string = findTypedElement(CueMultilineBytesLit.class);
+        assertTrue(string.isValidHost());
+        assertEquals(TextRange.create(4, 4), string.getLiteralContentRange());
+    }
+
+    @Test
+    public void contentRangePadded() {
+        myFixture.configureByText("a.cue", "##'''content<caret>'''##");
+        var string = findTypedElement(CueMultilineBytesLit.class);
+        assertEquals(TextRange.create(5, 12), string.getLiteralContentRange());
+    }
+
+    @Test
+    public void updateText() {
+        myFixture.configureByText("a.cue", "'''\ncontent<caret>\n'''");
+        var string = findTypedElement(CueMultilineBytesLit.class);
+
+        var newString1 = WriteCommandAction.runWriteCommandAction(getProject(), (Computable<PsiLanguageInjectionHost>)() -> {
+            return string.updateText("new");
+        });
+        assertTrue(newString1 instanceof CueMultilineBytesLit);
+        assertEquals("'''\nnew\n'''", newString1.getText());
+
+        var newEmptyString = WriteCommandAction.runWriteCommandAction(getProject(), (Computable<PsiLanguageInjectionHost>)() -> {
+            return string.updateText("");
+        });
+        assertTrue(newEmptyString instanceof CueMultilineBytesLit);
+        assertEquals("'''\n'''", newEmptyString.getText());
+    }
+
+    @Test
+    public void updateTextEscaped() {
+        myFixture.configureByText("a.cue", "'''\ncontent<caret>\n'''");
+        var string = findTypedElement(CueMultilineBytesLit.class);
+
+        // updating with text, which requires escapes, has to insert insert escaped characters
+        var replacement = WriteCommandAction.runWriteCommandAction(getProject(), (Computable<PsiLanguageInjectionHost>)() -> {
+            return string.updateText("new\t\tcontent\nnext line");
+        });
+        assertTrue(replacement instanceof CueMultilineBytesLit);
+        assertEquals("'''\nnew\t\tcontent\nnext line\n'''", replacement.getText());
+    }
+
+    @Test
+    public void updateTextEscapedPadded() {
+        myFixture.configureByText("a.cue", "###'''\ncontent<caret>\n'''###");
+        var string = findTypedElement(CueMultilineBytesLit.class);
+
+        // updating with text, which requires escapes, has to insert insert escaped characters
+        var replacement = WriteCommandAction.runWriteCommandAction(getProject(), (Computable<PsiLanguageInjectionHost>)() -> {
+            return string.updateText("new\t\tcontent\nnext line");
+        });
+        assertTrue(replacement instanceof CueMultilineBytesLit);
+        assertEquals("###'''\nnew\t\tcontent\nnext line\n'''###", replacement.getText());
+    }
+
+    @Test
+    public void updateTextEmpty() {
+        myFixture.configureByText("a.cue", "###'''\n'''###");
+        var string = findTypedElement(CueMultilineBytesLit.class);
+        assertTrue(string.isValidHost());
+
+        // updating with text, which requires escapes, has to insert insert escaped characters
+        var replacement = WriteCommandAction.runWriteCommandAction(getProject(), (Computable<PsiLanguageInjectionHost>)() -> {
+            return string.updateText("line\nline");
+        });
+        assertTrue(replacement instanceof CueMultilineBytesLit);
+        assertTrue(replacement.isValidHost());
+        assertEquals("###'''\nline\nline\n'''###", replacement.getText());
+    }
+
+    @Test
+    public void updateTextUnicode() {
+        myFixture.configureByText("a.cue", "'''\ncontent<caret>\n'''");
+        var string = findTypedElement(CueMultilineBytesLit.class);
+
+        var replacement = WriteCommandAction.runWriteCommandAction(getProject(), (Computable<PsiLanguageInjectionHost>)() -> {
+            return string.updateText("\\u65e5本\\U00008a9e");
+        });
+        assertTrue(replacement instanceof CueMultilineBytesLit);
+        assertEquals("'''\n\\u65e5本\\U00008a9e\n'''", replacement.getText());
+    }
+}

--- a/src/test/java/dev/monogon/cue/lang/psi/impl/CueMultilineStringLiteralMixinTest.java
+++ b/src/test/java/dev/monogon/cue/lang/psi/impl/CueMultilineStringLiteralMixinTest.java
@@ -1,0 +1,122 @@
+package dev.monogon.cue.lang.psi.impl;
+
+import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.util.Computable;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiLanguageInjectionHost;
+import dev.monogon.cue.CueLightTest;
+import dev.monogon.cue.lang.psi.CueMultilineStringLit;
+import org.junit.Test;
+
+public class CueMultilineStringLiteralMixinTest extends CueLightTest {
+    @Test
+    public void contentRange() {
+        myFixture.configureByText("a.cue", "\"\"\"\ncontent<caret>\n\"\"\"");
+        var string = findTypedElement(CueMultilineStringLit.class);
+        assertTrue(string.isValidHost());
+        assertEquals(TextRange.create(4, 11), string.getLiteralContentRange());
+    }
+
+    @Test
+    public void contentRangeEmpty() {
+        myFixture.configureByText("a.cue", "\"\"\"\n\"\"\"");
+        var string = findTypedElement(CueMultilineStringLit.class);
+        assertTrue(string.isValidHost());
+        assertEquals(TextRange.create(4, 4), string.getLiteralContentRange());
+    }
+
+    @Test
+    public void noLineFeed() {
+        myFixture.configureByText("a.cue", "\"\"\"content<caret>\"\"\"");
+        var string = findTypedElement(CueMultilineStringLit.class);
+        assertFalse(string.isValidHost());
+    }
+
+    @Test
+    public void contentRangePadded() {
+        myFixture.configureByText("a.cue", "##\"\"\"\ncontent<caret>\n\"\"\"##");
+        var string = findTypedElement(CueMultilineStringLit.class);
+        assertTrue(string.isValidHost());
+        assertEquals(TextRange.create(6, 13), string.getLiteralContentRange());
+    }
+
+    @Test
+    public void updateText() {
+        myFixture.configureByText("a.cue", "\"\"\"\ncontent<caret>\n\"\"\"");
+        var string = findTypedElement(CueMultilineStringLit.class);
+
+        var newString1 = WriteCommandAction.runWriteCommandAction(getProject(), (Computable<PsiLanguageInjectionHost>)() -> {
+            return string.updateText("new");
+        });
+        assertTrue(newString1 instanceof CueMultilineStringLit);
+        assertEquals("\"\"\"\nnew\n\"\"\"", newString1.getText());
+
+        var newEmptyString = WriteCommandAction.runWriteCommandAction(getProject(), (Computable<PsiLanguageInjectionHost>)() -> {
+            return string.updateText("");
+        });
+        assertTrue(newEmptyString instanceof CueMultilineStringLit);
+        assertEquals("\"\"\"\n\"\"\"", newEmptyString.getText());
+    }
+
+    @Test
+    public void updateLinefeedText() {
+        myFixture.configureByText("a.cue", "\"\"\"\ncontent<caret>\n\"\"\"");
+        var string = findTypedElement(CueMultilineStringLit.class);
+
+        var newString1 = WriteCommandAction.runWriteCommandAction(getProject(), (Computable<PsiLanguageInjectionHost>)() -> {
+            return string.updateText("new");
+        });
+        assertTrue(newString1 instanceof CueMultilineStringLit);
+        assertEquals("\"\"\"\nnew\n\"\"\"", newString1.getText());
+    }
+
+    @Test
+    public void updateTextEscaped() {
+        myFixture.configureByText("a.cue", "\"\"\"\ncontent<caret>\n\"\"\"");
+        var string = findTypedElement(CueMultilineStringLit.class);
+
+        // updating with text, which requires escapes, has to insert insert escaped characters
+        var replacement = WriteCommandAction.runWriteCommandAction(getProject(), (Computable<PsiLanguageInjectionHost>)() -> {
+            return string.updateText("new\t\tcontent\nnext line");
+        });
+        assertTrue(replacement instanceof CueMultilineStringLit);
+        assertEquals("\"\"\"\nnew\t\tcontent\nnext line\n\"\"\"", replacement.getText());
+    }
+
+    @Test
+    public void updateTextEscapedPadded() {
+        myFixture.configureByText("a.cue", "###\"\"\"\ncontent<caret>\n\"\"\"###");
+        var string = findTypedElement(CueMultilineStringLit.class);
+
+        // updating with text, which requires escapes, has to insert insert escaped characters
+        var replacement = WriteCommandAction.runWriteCommandAction(getProject(), (Computable<PsiLanguageInjectionHost>)() -> {
+            return string.updateText("new\t\tcontent\nnext line");
+        });
+        assertTrue(replacement instanceof CueMultilineStringLit);
+        assertEquals("###\"\"\"\nnew\t\tcontent\nnext line\n\"\"\"###", replacement.getText());
+    }
+
+    @Test
+    public void updateTextUnicode() {
+        myFixture.configureByText("a.cue", "\"\"\"\ncontent<caret>\n\"\"\"");
+        var string = findTypedElement(CueMultilineStringLit.class);
+
+        var replacement = WriteCommandAction.runWriteCommandAction(getProject(), (Computable<PsiLanguageInjectionHost>)() -> {
+            return string.updateText("\\u65e5本\\U00008a9e");
+        });
+        assertTrue(replacement instanceof CueMultilineStringLit);
+        assertEquals("\"\"\"\n\\u65e5本\\U00008a9e\n\"\"\"", replacement.getText());
+    }
+
+    @Test
+    public void updateWithTripleQuote() {
+        myFixture.configureByText("a.cue", "\"\"\"\ncontent<caret>\n\"\"\"");
+        var string = findTypedElement(CueMultilineStringLit.class);
+
+        var replacement = WriteCommandAction.runWriteCommandAction(getProject(), (Computable<PsiLanguageInjectionHost>)() -> {
+            return string.updateText("a\"\"\"b");
+        });
+        assertTrue(replacement instanceof CueMultilineStringLit);
+        assertEquals("triple quote in content must be escaped", "\"\"\"\na\\\"\"\"b\n\"\"\"", replacement.getText());
+    }
+}

--- a/src/test/java/dev/monogon/cue/lang/psi/impl/CueSimpleByteLiteralMixinTest.java
+++ b/src/test/java/dev/monogon/cue/lang/psi/impl/CueSimpleByteLiteralMixinTest.java
@@ -1,0 +1,72 @@
+package dev.monogon.cue.lang.psi.impl;
+
+import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.util.Computable;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiLanguageInjectionHost;
+import dev.monogon.cue.CueLightTest;
+import dev.monogon.cue.lang.psi.CueSimpleBytesLit;
+import org.junit.Test;
+
+public class CueSimpleByteLiteralMixinTest extends CueLightTest {
+    @Test
+    public void contentRange() {
+        myFixture.configureByText("a.cue", "'content<caret>'");
+        var string = findTypedElement(CueSimpleBytesLit.class);
+        assertNotNull(string);
+        assertEquals(TextRange.create(1, 8), string.getLiteralContentRange());
+    }
+
+    @Test
+    public void contentRangePadded() {
+        myFixture.configureByText("a.cue", "##'content<caret>'##");
+        var literal = findTypedElement(CueSimpleBytesLit.class);
+        assertNotNull(literal);
+        assertEquals(TextRange.create(3, 10), literal.getLiteralContentRange());
+    }
+
+    @Test
+    public void updateText() {
+        myFixture.configureByText("a.cue", "'content<caret>'");
+        var string = findTypedElement(CueSimpleBytesLit.class);
+        assertNotNull(string);
+
+        var newString1 = WriteCommandAction.runWriteCommandAction(getProject(), (Computable<PsiLanguageInjectionHost>)() -> {
+            return string.updateText("new");
+        });
+        assertTrue(newString1 instanceof CueSimpleBytesLit);
+        assertEquals("'new'", newString1.getText());
+
+        var newEmptyString = WriteCommandAction.runWriteCommandAction(getProject(), (Computable<PsiLanguageInjectionHost>)() -> {
+            return string.updateText("");
+        });
+        assertTrue(newEmptyString instanceof CueSimpleBytesLit);
+        assertEquals("''", newEmptyString.getText());
+    }
+
+    @Test
+    public void updateTextEscaped() {
+        myFixture.configureByText("a.cue", "'content<caret>'");
+        var string = findTypedElement(CueSimpleBytesLit.class);
+        assertNotNull(string);
+
+        // updating with text, which requires escapes, has to insert insert escaped characters
+        var replacement = WriteCommandAction.runWriteCommandAction(getProject(), (Computable<PsiLanguageInjectionHost>)() -> {
+            return string.updateText("new\t\tcontent\nnext line");
+        });
+        assertTrue(replacement instanceof CueSimpleBytesLit);
+        assertEquals("'new\t\tcontent\\nnext line'", replacement.getText());
+    }
+
+    @Test
+    public void updateTextUnicode() {
+        myFixture.configureByText("a.cue", "'content<caret>'");
+        var string = findTypedElement(CueSimpleBytesLit.class);
+
+        var replacement = WriteCommandAction.runWriteCommandAction(getProject(), (Computable<PsiLanguageInjectionHost>)() -> {
+            return string.updateText("\\u65e5本\\U00008a9e");
+        });
+        assertTrue(replacement instanceof CueSimpleBytesLit);
+        assertEquals("'\\u65e5本\\U00008a9e'", replacement.getText());
+    }
+}

--- a/src/test/java/dev/monogon/cue/lang/psi/impl/CueSimpleStringLiteralMixinTest.java
+++ b/src/test/java/dev/monogon/cue/lang/psi/impl/CueSimpleStringLiteralMixinTest.java
@@ -78,4 +78,28 @@ public class CueSimpleStringLiteralMixinTest extends CueLightTest {
         assertTrue(replacement instanceof CueSimpleStringLit);
         assertEquals("\"\\u65e5本\\U00008a9e\"", replacement.getText());
     }
+
+    @Test
+    public void updateTextInterpolation() {
+        myFixture.configureByText("a.cue", "\"content<caret>\"");
+        var string = findTypedElement(CueSimpleStringLit.class);
+
+        var replacement = WriteCommandAction.runWriteCommandAction(getProject(), (Computable<PsiLanguageInjectionHost>)() -> {
+            return string.updateText("a\\(123)b");
+        });
+        assertTrue(replacement instanceof CueSimpleStringLit);
+        assertEquals("content update with interpolation-like text must escape it", "\"a\\\\(123)b\"", replacement.getText());
+    }
+
+    @Test
+    public void updateTextInterpolationPadded() {
+        myFixture.configureByText("a.cue", "##\"content<caret>\"##");
+        var string = findTypedElement(CueSimpleStringLit.class);
+
+        var replacement = WriteCommandAction.runWriteCommandAction(getProject(), (Computable<PsiLanguageInjectionHost>)() -> {
+            return string.updateText("a\\(123)\\##(123)b");
+        });
+        assertTrue(replacement instanceof CueSimpleStringLit);
+        assertEquals("content update with interpolation-like text must escape it", "##\"a\\(123)\\##\\##(123)b\"##", replacement.getText());
+    }
 }

--- a/src/test/java/dev/monogon/cue/lang/psi/impl/CueSimpleStringLiteralMixinTest.java
+++ b/src/test/java/dev/monogon/cue/lang/psi/impl/CueSimpleStringLiteralMixinTest.java
@@ -1,0 +1,81 @@
+package dev.monogon.cue.lang.psi.impl;
+
+import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.util.Computable;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiLanguageInjectionHost;
+import dev.monogon.cue.CueLightTest;
+import dev.monogon.cue.lang.psi.CueSimpleStringLit;
+import org.junit.Test;
+
+public class CueSimpleStringLiteralMixinTest extends CueLightTest {
+    @Test
+    public void contentRange() {
+        myFixture.configureByText("a.cue", "\"content<caret>\"");
+        var string = findTypedElement(CueSimpleStringLit.class);
+        assertEquals(TextRange.create(1, 8), string.getLiteralContentRange());
+    }
+
+    @Test
+    public void contentRangePadded() {
+        myFixture.configureByText("a.cue", "##\"content<caret>\"##");
+        var string = findTypedElement(CueSimpleStringLit.class);
+        assertEquals(TextRange.create(3, 10), string.getLiteralContentRange());
+    }
+
+    @Test
+    public void updateText() {
+        myFixture.configureByText("a.cue", "\"content<caret>\"");
+        var string = findTypedElement(CueSimpleStringLit.class);
+
+        WriteCommandAction.runWriteCommandAction(getProject(), () -> {
+            var newString1 = string.updateText("new");
+            assertTrue(newString1 instanceof CueSimpleStringLit);
+            assertEquals("\"new\"", newString1.getText());
+        });
+
+        WriteCommandAction.runWriteCommandAction(getProject(), () -> {
+            var newEmptyString = string.updateText("");
+            assertTrue(newEmptyString instanceof CueSimpleStringLit);
+            assertEquals("\"\"", newEmptyString.getText());
+        });
+    }
+
+    @Test
+    public void updateTextEscaped() {
+        myFixture.configureByText("a.cue", "\"content<caret>\"");
+        var string = findTypedElement(CueSimpleStringLit.class);
+
+        // updating with text, which requires escapes, has to insert insert escaped characters
+        var replacement = WriteCommandAction.runWriteCommandAction(getProject(), (Computable<PsiLanguageInjectionHost>)() -> {
+            return string.updateText("new\t\tcontent\nnext line");
+        });
+        assertTrue(replacement instanceof CueSimpleStringLit);
+        assertEquals("\"new\t\tcontent\\nnext line\"", replacement.getText());
+    }
+
+    @Test
+    public void updateTextEscapedPadded() {
+        myFixture.configureByText("a.cue", "###\"content<caret>\"###");
+        var string = findTypedElement(CueSimpleStringLit.class);
+
+        // updating with text, which requires escapes, has to insert insert escaped characters
+        var replacement = WriteCommandAction.runWriteCommandAction(getProject(), (Computable<PsiLanguageInjectionHost>)() -> {
+            return string.updateText("new\t\tcontent\nnext line");
+        });
+        assertTrue(replacement instanceof CueSimpleStringLit);
+        assertEquals("###\"new\t\tcontent\\###nnext line\"###", replacement.getText());
+    }
+
+    @Test
+    public void updateTextUnicode() {
+        myFixture.configureByText("a.cue", "\"content<caret>\"");
+        var string = findTypedElement(CueSimpleStringLit.class);
+
+        var replacement = WriteCommandAction.runWriteCommandAction(getProject(), (Computable<PsiLanguageInjectionHost>)() -> {
+            return string.updateText("\\u65e5本\\U00008a9e");
+        });
+        assertTrue(replacement instanceof CueSimpleStringLit);
+        assertEquals("\"\\u65e5本\\U00008a9e\"", replacement.getText());
+    }
+}


### PR DESCRIPTION
Closes #4 
The IntelliLang plugin is now required.

Implement language injection into all string literals. 

Content entered in a fragment editor is automatically escaped. When interpolations are present, then the fragment editor displays read-only sections instead to allow editing around.

Language injection is a complex topic in IntelliJ, so this PR adds a bunch of test cases.